### PR TITLE
Approval mode: one screenshot, yes or no

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — 0.4.0
+
+Approval mode. A capability gap ("I can't do this": 2FA, a captcha) and an
+authority boundary ("I may not do this": submit the payment) were the same call
+with a different `reason`, and the outcome could not tell them apart. They are
+now two modes of `raiseHand`, and an approval needs no takeover at all: one
+screenshot, the action in words, yes or no. Additive — existing code compiles
+and behaves exactly as before.
+
+### Added
+
+- **`mode: "approval"`.** `raiseHand(page, { mode: "approval", reason, action })`
+  shows the human one screenshot and the concrete step, and resolves with
+  `approved` or `denied`. `action` is required in that mode and the types
+  enforce it; `raiseHand(page, { reason })` is unchanged and still a takeover.
+  `HandoffOutcome` grows by `approved` and `denied`, and `HandoffEvent` carries
+  `mode`, which is what makes `framesSent: 1` and `inputsApplied: 0` readable.
+- **Approval injects nothing.** No screencast, no CDP input, no focus probe, no
+  `storageState` capture, and no CDP session at all: the page the human decides
+  on is the page the agent stays on. One JPEG instead of 23–80 KB/s.
+- **The relay enforces the mode.** It is started as a takeover relay or an
+  approval relay and routes only that mode's human messages — `approve` and
+  `deny` in approval, the takeover set in takeover. Hiding a button is not a
+  restriction; the human's socket is reachable from any HTTP client.
+- **Deny is one tap, approve takes the 700ms hold** — the inversion of takeover
+  mode, where handing back is the tap and giving up is the hold. Here the
+  answer that cannot be taken back is yes, so the cost sits on that side.
+  Reasoning in [`docs/adr/0006`](docs/adr/0006-approval-mode.md).
+- **The LLM tool chooses the mode.** `needHumanToolSpec` takes optional `mode`
+  and `action`, its description explains "I can't" versus "I may not", and the
+  summary sentence covers the two new outcomes. An approval without an action
+  is refused rather than quietly downgraded to a takeover.
+- [`demo/approval.ts`](demo/approval.ts): a payment the agent has filled in and
+  will not submit without a yes.
+
+### Changed
+
+- The phone page serves both modes from one file, switched by a `data-mode` on
+  the body. In approval mode the input row, key bar and hand-back controls are
+  not on the page; pinch, drag and double-tap still zoom and pan the
+  screenshot, because an amount you cannot read is an approval you cannot give.
+- The relay no longer forwards non-text frames or unknown message types from
+  the human side. Both were previously relayed and then ignored by the agent,
+  so the closed message set is now closed at the relay rather than downstream.
+
 ## [0.3.0] - 2026-09-02
 
 The phone UI, rebuilt from a design-engineering audit
@@ -141,6 +186,7 @@ Initial release. Human-in-the-loop handoff for Solari cloud browsers.
   so two simultaneous handoffs is the plan-tier ceiling.
 - TypeScript/Node only.
 
+[Unreleased]: https://github.com/Sy-D/handraise/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/Sy-D/handraise/releases/tag/v0.3.0
 [0.2.0]: https://github.com/Sy-D/handraise/releases/tag/v0.2.0
 [0.1.0]: https://github.com/Sy-D/handraise/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,29 @@ Approval mode. A capability gap ("I can't do this": 2FA, a captcha) and an
 authority boundary ("I may not do this": submit the payment) were the same call
 with a different `reason`, and the outcome could not tell them apart. They are
 now two modes of `raiseHand`, and an approval needs no takeover at all: one
-screenshot, the action in words, yes or no. Additive — existing code compiles
-and behaves exactly as before.
+screenshot, the action in words, yes or no.
+
+What is unchanged: a `raiseHand(page, { reason })` call, a `switch` on
+`outcome` without an exhaustiveness guard, and anything that only reads a
+`HandoffEvent`. What is not: three exported types changed shape, and a
+TypeScript consumer may have to edit one line — the section below says which.
+
+### Breaking for TypeScript consumers
+
+Nothing changes at runtime for a takeover caller. These are compile-time
+breaks, and they apply even to an application that never asks for an approval.
+
+- **`HandoffOutcome` has two new members**, `approved` and `denied`. A
+  `Record<HandoffOutcome, X>` needs the two extra keys, and a `switch` with a
+  `never` exhaustiveness guard needs the two extra arms. The four existing
+  values keep their meaning.
+- **`HandoffEvent.mode` is new and required.** Reading an event is unchanged;
+  code that *constructs* one — a test fixture, a hand-built `onEvent` payload —
+  has to set it.
+- **`RaiseHandOptions` is now a union** of `TakeoverOptions | ApprovalOptions`,
+  so `interface Yours extends RaiseHandOptions` no longer compiles. Extend
+  `HandoffOptions` (everything both modes share) or `TakeoverOptions` instead;
+  both are exported.
 
 ### Added
 
@@ -21,7 +42,8 @@ and behaves exactly as before.
   `approved` or `denied`. `action` is required in that mode and the types
   enforce it; `raiseHand(page, { reason })` is unchanged and still a takeover.
   `HandoffOutcome` grows by `approved` and `denied`, and `HandoffEvent` carries
-  `mode`, which is what makes `framesSent: 1` and `inputsApplied: 0` readable.
+  `mode`, which is what makes `inputsApplied: 0` and `framesSent: 1 +
+  reconnects` readable.
 - **Approval injects nothing.** No screencast, no CDP input, no focus probe, no
   `storageState` capture, and no CDP session at all: the page the human decides
   on is the page the agent stays on. One JPEG instead of 23–80 KB/s.
@@ -49,6 +71,46 @@ and behaves exactly as before.
 - The relay no longer forwards non-text frames or unknown message types from
   the human side. Both were previously relayed and then ignored by the agent,
   so the closed message set is now closed at the relay rather than downstream.
+
+### Fixed
+
+- **The phone's Clear key did nothing.** `clear` was in the protocol, the relay
+  routed it and `input.ts` implemented it, but the agent's own message switch
+  never listed it, so it was dropped one hop short of the page. The human
+  pressed a key that gave feedback and changed nothing. A test now sends one of
+  every message the protocol defines through the real relay and the real
+  socket, so the three vocabularies cannot drift apart again.
+- **An answer given while the phone's socket was closing was thrown away.** If
+  the socket had started closing when the human tapped, the message went into
+  the outbox, the page showed the ending, and the socket's close handler then
+  stopped reconnecting because the page was "finished" — with the answer still
+  queued. The human saw "Handed back" or "Approved" and the agent waited out
+  its full timeout. The page now keeps reconnecting until the outbox is empty.
+  Present since 0.3.0 for hand back and give up.
+- **An unknown `mode` is refused before anything is created**, rather than
+  falling open as a takeover. TypeScript closes it; this package also ships as
+  JavaScript. An approval with a blank or whitespace-only `action` is refused
+  the same way, in `raiseHand` and in the `needHuman` tool: a human cannot
+  approve a sentence that is not there.
+
+### Security
+
+- **The first answer wins, permanently.** The handoff link is a bearer URL and
+  can be in two hands at once. A terminal message from the human ended the
+  handoff but did not lock the relay, so a second holder could overwrite a
+  queued `deny` with an `approve` before the agent reconnected to collect it —
+  and the agent would act on the second one. The relay now takes the first
+  answer, refuses every human message after it, and refuses to let a
+  reconnecting agent refill the replay buffers it has just scrubbed. Present
+  since 0.2.0 for hand back and give up.
+- **The relay forgets the page when its agent disconnects.** Replay buffers
+  were purged only when the agent's `ended` arrived, and that message is not
+  guaranteed: the agent gives up on it after two seconds, and a sandbox that
+  fails to be destroyed stays public until it idles out. Anyone holding the
+  link could be served the last frame of a logged-in page in that window. The
+  relay now drops the last frame, state and focus the moment the authenticated
+  agent socket closes; a handoff that is still running restores them by itself
+  on the next reconnect.
 
 ## [0.3.0] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,8 +109,10 @@ breaks, and they apply even to an application that never asks for an approval.
   fails to be destroyed stays public until it idles out. Anyone holding the
   link could be served the last frame of a logged-in page in that window. The
   relay now drops the last frame, state and focus the moment the authenticated
-  agent socket closes; a handoff that is still running restores them by itself
-  on the next reconnect.
+  agent socket closes. On the next reconnect the agent re-sends its state at
+  once; the frame comes back with the next repaint in takeover mode or the
+  re-sent screenshot in approval mode, so a late human may briefly see a blank
+  stage but never the previous logged-in frame.
 
 ## [0.3.0] - 2026-09-02
 

--- a/README.md
+++ b/README.md
@@ -59,12 +59,22 @@ if (answer.outcome !== "approved") return   // "denied", "timeout", "disconnecte
 ```
 
 One screenshot, no live stream, and nothing is injected into the page: the
-agent still owns the session and carries out the action itself. On the phone,
+agent still owns the session and carries out the action itself. (The event's
+`framesSent` counts that screenshot once per connection — `1 + reconnects` —
+because a reconnecting agent has to put it back on the wire.) On the phone,
 **Deny is one tap** and **Approve takes a 700ms hold** — the reverse of
 takeover mode, because here the answer that cannot be taken back is yes. The
 relay enforces it too: an approval relay routes `approve` and `deny` and drops
 every takeover message, so the restriction is not just a hidden button
 ([`docs/adr/0006`](docs/adr/0006-approval-mode.md)).
+
+Upgrading from 0.3.0: nothing changes at runtime, and `raiseHand(page, { reason })`
+compiles as it did. Three exported types changed shape, so a TypeScript
+consumer may have one edit to make even if they never ask for an approval —
+`HandoffOutcome` has two new members, `HandoffEvent.mode` is new and required,
+and `RaiseHandOptions` is now a union (extend `HandoffOptions` or
+`TakeoverOptions` instead of it). The
+[CHANGELOG](CHANGELOG.md) has the detail.
 
 Runnable without writing any code: [`demo/try.ts`](demo/try.ts) raises a hand
 immediately so you can drive it; [`demo/approval.ts`](demo/approval.ts) asks

--- a/README.md
+++ b/README.md
@@ -43,9 +43,33 @@ Measured against the live API, method and raw data in
 - **30/30 handoffs resolved** in the latency benchmark.
 - **3.5 s median** from raise to live on the phone.
 
+## Approval mode
+
+Sometimes the agent is not stuck — it is about to do something it may not
+decide alone. That needs no takeover: the human sees a screenshot, the reason
+and the exact step, and answers.
+
+```ts
+const answer = await raiseHand(page, {
+  mode: "approval",
+  reason: "The agent may not move money without a human",
+  action: "Submit $12,430 vendor payment to Acme GmbH",
+})
+if (answer.outcome !== "approved") return   // "denied", "timeout", "disconnected"
+```
+
+One screenshot, no live stream, and nothing is injected into the page: the
+agent still owns the session and carries out the action itself. On the phone,
+**Deny is one tap** and **Approve takes a 700ms hold** — the reverse of
+takeover mode, because here the answer that cannot be taken back is yes. The
+relay enforces it too: an approval relay routes `approve` and `deny` and drops
+every takeover message, so the restriction is not just a hidden button
+([`docs/adr/0006`](docs/adr/0006-approval-mode.md)).
+
 Runnable without writing any code: [`demo/try.ts`](demo/try.ts) raises a hand
-immediately so you can drive it; [`demo/github-2fa.ts`](demo/github-2fa.ts)
-does the real 2FA wall and keeps the session the handoff earned.
+immediately so you can drive it; [`demo/approval.ts`](demo/approval.ts) asks
+you to approve a payment; [`demo/github-2fa.ts`](demo/github-2fa.ts) does the
+real 2FA wall and keeps the session the handoff earned.
 
 ## What this actually is
 
@@ -77,16 +101,23 @@ const tools = {
 
 The tool returns `{ outcome, summary, durationMs }`, where `summary` is a
 sentence the model can act on ("A human fixed the problem and handed the
-browser back. Re-read the page and continue.").
+browser back. Re-read the page and continue.", or "The human refused the
+action. Do not carry it out and do not ask again for the same step.").
+
+The model also chooses the mode: it passes `mode: "approval"` plus an `action`
+when it could do the step but must not decide alone, and the tool refuses an
+approval that names no action rather than quietly handing the browser over.
 
 [`demo/agent.ts`](demo/agent.ts) is a real agent loop where the model itself
 decides to call `needHuman` when it hits the 2FA wall — run it with
 `DEMO_SIM=1` for the scripted version.
 
 **Two classes of interrupt, one call.** A *capability gap* — 2FA, a captcha, an
-unfamiliar UI — is the agent admitting it cannot. An *authority boundary* —
-approval before an irreversible step — is the agent choosing not to. Both are
-the same call today with a different `reason`.
+unfamiliar UI — is the agent admitting it cannot: `mode: "takeover"`, the
+default. An *authority boundary* — a yes before an irreversible step — is the
+agent not being allowed to: `mode: "approval"`. The model picks, by passing
+`mode` and `action` to the same tool; the tool description says which is
+which.
 
 ## How it works
 
@@ -134,6 +165,13 @@ primary. The dot in the header shows the connection: white is live, pulsing
 grey is reconnecting (your input is queued and sent in order once it is back),
 red means the handoff has ended.
 
+**In approval mode the same page has a different job.** One screenshot instead
+of the stream, the action in the largest type on the screen, and no keyboard,
+key bar or input row — nothing there can reach the remote page. Pinch, drag and
+double-tap still zoom and pan the screenshot, because an amount you cannot read
+is an approval you cannot give. **Deny** is one tap and **Hold to approve**
+takes the 700ms; the ending says which one happened.
+
 ## Getting notified
 
 Three ways, no vendor lock-in:
@@ -159,6 +197,8 @@ await raiseHand(page, {
 | Option | Type | Default | |
 |---|---|---|---|
 | `reason` | `string` | *required* | Shown to the human on the handoff page. |
+| `mode` | `"takeover"` \| `"approval"` | `"takeover"` | `takeover` hands the live browser over; `approval` shows one screenshot and asks for a yes or a no. |
+| `action` | `string` | *required in approval mode* | The exact step being decided, e.g. "Submit $12,430 vendor payment to Acme GmbH". A type error if `mode` is `"approval"` and it is missing. |
 | `timeoutMs` | `number` | 5 minutes | How long to wait for the human. |
 | `webhookUrl` | `string` | — | Generic JSON POST when the link is ready. |
 | `onUrl` | `(url) => void` | — | Called with the handoff URL. |
@@ -172,10 +212,19 @@ await raiseHand(page, {
 
 | Field | |
 |---|---|
-| `outcome` | `"resolved"` \| `"aborted"` \| `"timeout"` \| `"disconnected"` |
+| `outcome` | See below. |
 | `durationMs` | Wall-clock time the human took. |
 | `url` | The handoff URL. |
-| `storageState` | Cookies + localStorage captured right after a successful handback — persist it (e.g. to a Solari profile) and the human's work survives even if the session dies later. |
+| `storageState` | Cookies + localStorage captured right after a successful handback — persist it (e.g. to a Solari profile) and the human's work survives even if the session dies later. Takeover mode only: an approval changes nothing on the page. |
+
+| `outcome` | Mode | Means |
+|---|---|---|
+| `resolved` | takeover | The human handed the browser back. |
+| `aborted` | takeover | The human looked and could not solve it. Do not retry the same step. |
+| `approved` | approval | Carry out the action. |
+| `denied` | approval | Do not carry out the action. |
+| `timeout` | both | Nobody answered within `timeoutMs`. |
+| `disconnected` | both | The browser session died mid-handoff. |
 
 ## What happens when things die
 
@@ -275,6 +324,9 @@ with `isTrusted: true`.
   protocol change.)
 - Solari's $20 plan allows 2 concurrent sandboxes; each active handoff uses
   one. Two simultaneous handoffs is the plan-tier ceiling.
+- An approval shows the page as it was when the agent asked. If the page
+  changes underneath (a session expiring, a redirect), the human is deciding on
+  a stale picture — the frame is not refreshed.
 - TypeScript/Node only for now.
 
 ## Contributing

--- a/demo/approval.ts
+++ b/demo/approval.ts
@@ -1,0 +1,67 @@
+/**
+ * The other half of handraise, in one run:
+ *
+ *   bun --env-file=.env demo/approval.ts   # only needs the Solari key
+ *
+ * The agent is not stuck here. It has filled in a payment it is not allowed to
+ * submit on its own, so it asks. Scan the QR code, read the amount off the
+ * screenshot, and answer: Deny is one tap, Approve takes a 700ms hold. The
+ * browser stays with the agent either way — nothing is injected into the page.
+ */
+import { Solari } from "@solarisdk/browser"
+import type { Page } from "playwright-core"
+import { raiseHand } from "../src/index"
+
+/** A payment the agent has filled in and stopped in front of. */
+const PAYMENT = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Acme — Confirm payment</title>
+<style>
+  body { font: 16px/1.5 -apple-system, system-ui, sans-serif; margin: 0; background: #f6f7f9; color: #111; }
+  main { max-width: 520px; margin: 64px auto; background: #fff; border: 1px solid #e3e5e8; border-radius: 12px; padding: 32px; }
+  h1 { font-size: 20px; margin: 0 0 24px; }
+  dl { display: grid; grid-template-columns: 140px 1fr; gap: 12px 16px; margin: 0 0 28px; }
+  dt { color: #6b7280; } dd { margin: 0; font-weight: 600; }
+  .total { font-size: 28px; }
+  button { font: inherit; font-weight: 600; padding: 12px 20px; border-radius: 8px; border: 0; background: #111; color: #fff; }
+</style></head>
+<body><main>
+  <h1>Confirm payment</h1>
+  <dl>
+    <dt>Payee</dt><dd>Acme GmbH</dd>
+    <dt>IBAN</dt><dd>DE02 1203 0000 0000 2020 51</dd>
+    <dt>Reference</dt><dd>Invoice 2026-0417</dd>
+    <dt>Amount</dt><dd class="total">EUR 12,430.00</dd>
+  </dl>
+  <button type="button">Submit payment</button>
+</main></body></html>`
+
+const ACTION = "Submit the EUR 12,430.00 payment to Acme GmbH"
+
+const solari = new Solari({ apiKey: process.env.SOLARI_API_KEY ?? "" })
+
+const browser = await solari.launch()
+try {
+  // SAFETY: `@solarisdk/browser` returns patchright-core's Page, a Playwright
+  // fork with the identical runtime surface handraise uses (goto, context(),
+  // screenshot). The declarations differ only in optional-property variance
+  // under exactOptionalPropertyTypes; the e2e drives this same cast.
+  const page = (await browser.newPage()) as Page
+  await page.setContent(PAYMENT)
+
+  const result = await raiseHand(page, {
+    mode: "approval",
+    reason: "The agent may not move money without a human",
+    action: ACTION,
+    timeoutMs: 4 * 60_000,
+  })
+
+  console.log(
+    `\n${result.outcome} after ${Math.round(result.durationMs / 1000)}s — ` +
+      (result.outcome === "approved"
+        ? "the agent would submit the payment now."
+        : "the agent leaves the payment unsubmitted."),
+  )
+} finally {
+  await browser.close()
+  await solari.close()
+}

--- a/docs/adr/0006-approval-mode.md
+++ b/docs/adr/0006-approval-mode.md
@@ -1,0 +1,112 @@
+# 0006 — Approval mode: one screenshot, a hold on yes
+
+- **Status:** accepted
+- **Date:** 2026-09-02
+
+## Context
+
+Two different things stop an agent, and until now they were the same call.
+
+A **capability gap** is "I can't do this": a 2FA prompt, a captcha, a page the
+model does not understand. The human has to take the browser, do the thing, and
+give it back. That is what `raiseHand` has always done.
+
+An **authority boundary** is "I may not do this": submit the payment, send the
+mail, delete the bucket. The agent knows exactly how. It is not allowed to
+decide alone. Handing the browser over to get a yes is the wrong shape — it
+gives away control of a live session to answer a question, it needs a
+screencast and an input path that nobody uses, and it cannot work in a chat
+channel, which is where approvals actually happen.
+
+Both were reachable before this ADR by writing a different `reason`, which left
+the outcome (`resolved`) unable to say whether the human had agreed or merely
+looked.
+
+## Decision
+
+**A second mode on the same call**, selected by `mode: "approval"`, with
+`action` required alongside it:
+
+```ts
+await raiseHand(page, { reason })                                  // takeover
+await raiseHand(page, { mode: "approval", reason, action })        // approval
+```
+
+The type is a discriminated union, so `raiseHand(page, { reason })` compiles
+exactly as before and `mode: "approval"` will not compile without an `action`.
+`HandoffOutcome` grows by `approved` and `denied`; takeover can produce
+`resolved` and `aborted`, approval the two new ones, and both can end in
+`timeout` or `disconnected`.
+
+Three decisions follow from the shape of the question.
+
+**One screenshot, not a screencast.** An approval is about a moment — the page
+as the agent left it. The frame is a single JPEG taken with `page.screenshot`,
+sent as the existing `frame` message so the phone's letterbox, zoom and pan
+maths do not change. No CDP session is opened at all: no screencast, no input
+target, no focus probe, no `storageState` capture. The human's answer costs one
+frame instead of 23–80 KB/s, and the same one frame is what a chat channel can
+carry as an attachment.
+
+**The relay owns the mode, and enforces it.** The relay process is started as a
+takeover relay or an approval relay (argv, never a message) and routes only
+that mode's human messages: `tap`, `char`, `key`, `clear`, `scroll`, `handback`
+and `abort` in takeover; `approve` and `deny` in approval. Everything else from
+the human side is dropped, and the page is served with the mode baked into its
+`<body>`. Hiding a button is not a restriction — the human's WebSocket is
+reachable from any HTTP client. `runHandoff` applies the same rule a second
+time, so a relay that is not the one this version shipped still cannot make an
+approval settle as `resolved`.
+
+**Deny is one tap; approve takes the 700 ms hold.** This is the inversion of
+takeover mode, where "Hand back" is a tap and "I can't do this" is the hold. In
+a takeover the irreversible answer is giving up. In an approval the
+irreversible answer is yes: the money moves, the mail goes, the bucket is gone.
+So the cost of the gesture moves to the side that carries the consequence, and
+the safe answer stays as cheap as possible. The hold's progress fill is
+monochrome rather than the interface's one red, which stays reserved for
+destructive things.
+
+## Alternatives
+
+- **A separate function (`requestApproval`).** Rejected: it duplicates the
+  whole relay lifecycle, the QR, the webhook, the wide event and the timeout
+  contract for a difference that is one branch wide, and it splits the tool
+  surface an LLM has to choose from into two tools instead of one parameter.
+- **`action` as an optional field on the existing options.** Rejected: an
+  approval without a named step puts a blank question on a phone. The type
+  system can prevent that, so it does.
+- **Reuse `resolved`/`aborted` for the two answers.** Rejected: a caller
+  branching on `resolved` would treat a denial as success in takeover code that
+  was never written with approvals in mind. New meanings get new names.
+- **Send the screencast anyway and just hide the controls.** Rejected: it pays
+  the streaming cost for a still image, keeps an input path alive that must
+  never fire, and makes the relay's refusal a matter of the phone's UI rather
+  than the server's routing.
+- **Approve as a tap, deny behind the hold** (symmetry with takeover).
+  Rejected: it puts the guard on the answer that changes nothing and leaves the
+  irreversible one a thumb-brush away.
+- **A confirm dialog on approve** instead of the hold. Rejected for the reason
+  0.3.0 already rejected it for the give-up button: a dialog costs a screen and
+  trains people to dismiss it, while the hold is the confirmation.
+
+## Consequences
+
+- **`HandoffOutcome` has six members.** Existing `switch` statements still
+  compile and still branch identically; only code that exhaustively matches the
+  union has to add two arms, and only if it ever asks for approvals.
+- **`HandoffEvent` carries `mode`.** Which outcomes, frame counts and input
+  counts are possible follows from it, so the one wide event per handoff stays
+  self-describing: an approval reports `framesSent: 1`, `inputsApplied: 0` and
+  `storageStateCaptured: false` by construction.
+- **An approval leaves the page untouched.** The agent continues on the same
+  page it stopped on, with nothing injected, so the caller can carry out the
+  approved action itself and know exactly what it is acting on.
+- **The human message set stays closed and is now mode-scoped.** The relay also
+  stopped forwarding non-text frames from the human side and unknown message
+  types, both of which were previously relayed and then ignored by the agent.
+- **The phone is one page in two modes.** Two footers and one `data-mode`
+  attribute, rather than a second page to keep in sync with the first.
+- Not covered here: notifying a chat channel with the screenshot and two
+  buttons. That is the point of the single frame, and it belongs to the channel
+  adapters, not to this library.

--- a/docs/adr/0006-approval-mode.md
+++ b/docs/adr/0006-approval-mode.md
@@ -63,9 +63,18 @@ takeover mode, where "Hand back" is a tap and "I can't do this" is the hold. In
 a takeover the irreversible answer is giving up. In an approval the
 irreversible answer is yes: the money moves, the mail goes, the bucket is gone.
 So the cost of the gesture moves to the side that carries the consequence, and
-the safe answer stays as cheap as possible. The hold's progress fill is
-monochrome rather than the interface's one red, which stays reserved for
-destructive things.
+the safe answer stays as cheap as possible.
+
+**The gesture is the only asymmetry.** The two buttons are drawn identically —
+both outlined, neither carrying the interface's near-white accent — because the
+rule the 0.3.0 UI was rebuilt around is that the accent marks the action the
+interface wants, or nothing (`docs/design/phone-ui-audit.md`). A takeover has
+such an action: "Hand back". An approval does not; that is its premise. An
+accent on Deny would make the interface recommend an answer, and a human who
+glances at a phone and taps the loudest thing would file a false denial — cheap
+to recover from once, and exactly the habit that makes the next approval screen
+dangerous. The hold's progress fill is monochrome rather than the interface's
+one red, which stays reserved for destructive things.
 
 ## Alternatives
 
@@ -97,14 +106,21 @@ destructive things.
   union has to add two arms, and only if it ever asks for approvals.
 - **`HandoffEvent` carries `mode`.** Which outcomes, frame counts and input
   counts are possible follows from it, so the one wide event per handoff stays
-  self-describing: an approval reports `framesSent: 1`, `inputsApplied: 0` and
-  `storageStateCaptured: false` by construction.
+  self-describing: an approval reports `inputsApplied: 0` and
+  `storageStateCaptured: false` by construction, and `framesSent: 1 +
+  reconnects` — the screenshot is re-sent on every reconnect, because a relay
+  that restarted underneath the handoff has nothing to replay to the phone.
 - **An approval leaves the page untouched.** The agent continues on the same
   page it stopped on, with nothing injected, so the caller can carry out the
   approved action itself and know exactly what it is acting on.
 - **The human message set stays closed and is now mode-scoped.** The relay also
   stopped forwarding non-text frames from the human side and unknown message
   types, both of which were previously relayed and then ignored by the agent.
+- **The first answer wins, permanently.** Two answers are now possible where
+  there used to be one shape of ending, and the link is a bearer URL that can
+  be in two hands: a second holder must not be able to overturn the first one's
+  `deny` with an `approve` while the agent is reconnecting. The relay locks on
+  the first terminal message from the human, in both modes.
 - **The phone is one page in two modes.** Two footers and one `data-mode`
   attribute, rather than a second page to keep in sync with the first.
 - Not covered here: notifying a chat channel with the screenshot and two

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,6 +13,7 @@ pre-publish security review — they document the history, they do not invent it
 | [0003](0003-no-keep-alive-five-minute-wait.md) | No browser keep-alive, 5-minute default wait, storageState capture | accepted | [Measurement 04](../measurements/04-browser-session-lifetime.md) |
 | [0004](0004-separate-agent-secret-closed-message-set.md) | Agent role via a separate secret, and a closed human message set | accepted | Security review |
 | [0005](0005-handoff-not-wall-detection.md) | handraise is the handoff mechanism, not the wall detection | accepted | Scope decision |
+| [0006](0006-approval-mode.md) | Approval mode: one screenshot, a hold on yes | accepted | Scope decision |
 
 ## Format
 

--- a/e2e/handoff.e2e.ts
+++ b/e2e/handoff.e2e.ts
@@ -304,6 +304,13 @@ try {
     check(event?.mode === "approval", "the wide event carries the mode")
     check(event?.inputsApplied === 0, "no input was applied to the page")
     check(event?.framesSent === 1, "the wide event counts the one frame")
+    // The `ended` message is written as the handoff settles, so it can still
+    // be in flight when raiseHand returns — an approval tears down in
+    // milliseconds. Wait for it rather than race it.
+    const endingDeadline = Date.now() + 5_000
+    while (human.ending() === null && Date.now() < endingDeadline) {
+      await Bun.sleep(50)
+    }
     check(human.ending() === expected, "the phone was told how it ended")
     await human.close()
 

--- a/e2e/handoff.e2e.ts
+++ b/e2e/handoff.e2e.ts
@@ -30,6 +30,17 @@ import { startTestApp } from "../test-app/deploy"
 import { msUntilNextStep, totp } from "../test-app/totp"
 import { openHandoffPage } from "./human-sim"
 
+declare global {
+  interface Window {
+    /** Installed by the approval cases; see `watchForInput` below. */
+    handraiseInputCounts?: {
+      pointerdown: number
+      keydown: number
+      input: number
+    }
+  }
+}
+
 const FAULT = process.env.HANDRAISE_E2E_FAULT ?? ""
 const VIEWPORT = { width: 1280, height: 800 }
 const TIMEOUT_CASE_MS = 8_000
@@ -269,9 +280,35 @@ try {
       `the phone shows the reason (${answer})`,
     )
 
-    // Approval injects nothing. A tap from the same socket the answer comes
-    // from must not reach the page, and the relay is the one refusing it.
-    const before = page.url()
+    // Approval injects nothing, and this is the only place that can be proven
+    // against the real page: count what the page itself would see if a tap or
+    // a keystroke ever landed on it. `inputsApplied` cannot fail — there is no
+    // input target in approval mode — but these listeners can.
+    await page.evaluate(() => {
+      const counts = { pointerdown: 0, keydown: 0, input: 0 }
+      window.handraiseInputCounts = counts
+      document.addEventListener(
+        "pointerdown",
+        () => {
+          counts.pointerdown += 1
+        },
+        true,
+      )
+      document.addEventListener(
+        "keydown",
+        () => {
+          counts.keydown += 1
+        },
+        true,
+      )
+      document.addEventListener(
+        "input",
+        () => {
+          counts.input += 1
+        },
+        true,
+      )
+    })
     await human.tap(10, 10)
     await human.type("9", 0)
     await Bun.sleep(500)
@@ -295,23 +332,32 @@ try {
       result.outcome === expected,
       `an approval answered with ${answer} reports ${expected}`,
     )
-    check(page.url() === before, "nothing the human sent moved the page")
+    const counts = await page.evaluate(() => window.handraiseInputCounts)
     check(
-      human.frameCount() === 1,
-      `exactly one screenshot was sent (saw ${human.frameCount()})`,
+      counts?.pointerdown === 0 && counts?.keydown === 0 && counts?.input === 0,
+      `the page saw no pointer, key or input event (${JSON.stringify(counts)})`,
+    )
+    check(
+      human.frameCount() === 1 + (event?.reconnects ?? 0),
+      `the phone got the screenshot once per connection (${human.frameCount()} frames, ${event?.reconnects} reconnects)`,
     )
     check(result.storageState === undefined, "an approval captures no cookies")
     check(event?.mode === "approval", "the wide event carries the mode")
-    check(event?.inputsApplied === 0, "no input was applied to the page")
-    check(event?.framesSent === 1, "the wide event counts the one frame")
-    // The `ended` message is written as the handoff settles, so it can still
-    // be in flight when raiseHand returns — an approval tears down in
-    // milliseconds. Wait for it rather than race it.
-    const endingDeadline = Date.now() + 5_000
-    while (human.ending() === null && Date.now() < endingDeadline) {
-      await Bun.sleep(50)
-    }
-    check(human.ending() === expected, "the phone was told how it ended")
+    check(event?.inputsApplied === 0, "the wide event reports no input applied")
+    check(
+      event?.framesSent === 1 + (event?.reconnects ?? 0),
+      `the wide event counts one frame per connection (${event?.framesSent} frames, ${event?.reconnects} reconnects)`,
+    )
+    // Deliberately observed and not asserted. The ending is relayed while the
+    // relay sandbox is already being destroyed, and an approval tears down in
+    // milliseconds — there is no storageState capture to hold the door open,
+    // as there is in the takeover case above, which does assert it. A phone
+    // that answered does not depend on this message: it shows its own ending
+    // the moment the human taps. A second viewer of the link does, and that
+    // path is covered offline, where the relay is not being killed underneath
+    // it: relay.test.ts "a human who joins after the handoff ended sees the
+    // ending, not the frame" and the ui.spec terminal-overlay tests.
+    log("phone_ending", { seen: human.ending() ?? "none", expected })
     await human.close()
 
     const gone = await fetch(approvalUrl, { cache: "no-store" })

--- a/e2e/handoff.e2e.ts
+++ b/e2e/handoff.e2e.ts
@@ -24,6 +24,7 @@
 import { Solari } from "@solarisdk/browser"
 import type { Page } from "playwright-core"
 
+import type { HandoffEvent } from "../src/events"
 import { raiseHand } from "../src/index"
 import { startTestApp } from "../test-app/deploy"
 import { msUntilNextStep, totp } from "../test-app/totp"
@@ -230,6 +231,89 @@ try {
     `the relay sandbox is gone (${relayGone.status})`,
   )
   await relayGone.text()
+
+  // --- Approval: the human answers a question, and drives nothing --------
+  //
+  // The other half of the product. No screencast, no input path: one
+  // screenshot, the action in words, and a yes or a no.
+  const APPROVAL_ACTION = "Transfer EUR 12,430.00 to Acme GmbH"
+
+  async function askApproval(answer: "approve" | "deny"): Promise<void> {
+    const askedAt = Date.now()
+    let approvalUrl = ""
+    let event: HandoffEvent | undefined
+    const asking = raiseHand(page, {
+      mode: "approval",
+      reason: "The agent may not move money without a human",
+      action: APPROVAL_ACTION,
+      qr: false,
+      timeoutMs: 60_000,
+      onUrl: (url) => {
+        approvalUrl = url
+      },
+      onEvent: (raised) => {
+        event = raised
+      },
+    })
+    pending = asking
+
+    while (approvalUrl === "") await Bun.sleep(50)
+    const human = await openHandoffPage(approvalUrl)
+    await human.waitForFrame()
+    check(
+      human.action() === APPROVAL_ACTION,
+      `the phone shows the action verbatim (${answer})`,
+    )
+    check(
+      human.reason() === "The agent may not move money without a human",
+      `the phone shows the reason (${answer})`,
+    )
+
+    // Approval injects nothing. A tap from the same socket the answer comes
+    // from must not reach the page, and the relay is the one refusing it.
+    const before = page.url()
+    await human.tap(10, 10)
+    await human.type("9", 0)
+    await Bun.sleep(500)
+
+    if (answer === "approve") await human.approve()
+    else await human.deny()
+
+    const result = await asking
+    pending = null
+    timings[`approval${answer}Ms`] = Date.now() - askedAt
+    log("approval_done", {
+      answer,
+      outcome: result.outcome,
+      durationMs: result.durationMs,
+      frames: human.frameCount(),
+      ms: timings[`approval${answer}Ms`],
+    })
+
+    const expected = answer === "approve" ? "approved" : "denied"
+    check(
+      result.outcome === expected,
+      `an approval answered with ${answer} reports ${expected}`,
+    )
+    check(page.url() === before, "nothing the human sent moved the page")
+    check(
+      human.frameCount() === 1,
+      `exactly one screenshot was sent (saw ${human.frameCount()})`,
+    )
+    check(result.storageState === undefined, "an approval captures no cookies")
+    check(event?.mode === "approval", "the wide event carries the mode")
+    check(event?.inputsApplied === 0, "no input was applied to the page")
+    check(event?.framesSent === 1, "the wide event counts the one frame")
+    check(human.ending() === expected, "the phone was told how it ended")
+    await human.close()
+
+    const gone = await fetch(approvalUrl, { cache: "no-store" })
+    await gone.text()
+    check(gone.status !== 200, `the approval relay is gone (${gone.status})`)
+  }
+
+  await askApproval("approve")
+  await askApproval("deny")
 
   // --- The cheap second case: nobody comes -------------------------------
   const timeoutAt = Date.now()

--- a/e2e/human-sim.ts
+++ b/e2e/human-sim.ts
@@ -18,6 +18,7 @@ import {
   HEARTBEAT_INTERVAL_MS,
   type HumanToAgent,
 } from "../src/relay/protocol"
+import type { HandoffOutcome } from "../src/types"
 
 export interface ReceivedFrame {
   /** Base64 JPEG, exactly as CDP produced it. */
@@ -31,8 +32,10 @@ export interface SimulatedHuman {
   frameCount(): number
   /** The `reason` currently shown in the header. */
   reason(): string
+  /** The `action` the agent asked approval for, empty in takeover mode. */
+  action(): string
   /** How the agent said the handoff ended, if it has. */
-  ending(): "resolved" | "aborted" | "timeout" | "disconnected" | null
+  ending(): HandoffOutcome | null
   waitForFrame(timeoutMs?: number): Promise<ReceivedFrame>
   tap(fx: number, fy: number): Promise<void>
   /** Type one character per message, the way the mobile UI does. */
@@ -41,6 +44,9 @@ export interface SimulatedHuman {
   scroll(fdy: number): Promise<void>
   handback(): Promise<void>
   abort(): Promise<void>
+  /** Approval mode only; the relay drops these in takeover mode. */
+  approve(): Promise<void>
+  deny(): Promise<void>
   close(): Promise<void>
 }
 
@@ -86,7 +92,8 @@ export async function openHandoffPage(
   let frame: ReceivedFrame | null = null
   let frames = 0
   let reason = ""
-  let ending: "resolved" | "aborted" | "timeout" | "disconnected" | null = null
+  let action = ""
+  let ending: HandoffOutcome | null = null
   const waiters: (() => void)[] = []
 
   socket.on("message", (data: Buffer) => {
@@ -98,7 +105,10 @@ export async function openHandoffPage(
       while (waiters.length > 0) waiters.pop()?.()
       return
     }
-    if (message.type === "state") reason = message.reason
+    if (message.type === "state") {
+      reason = message.reason
+      action = message.action ?? ""
+    }
     if (message.type === "ended") ending = message.outcome
   })
 
@@ -125,6 +135,7 @@ export async function openHandoffPage(
     lastFrame: () => frame,
     frameCount: () => frames,
     reason: () => reason,
+    action: () => action,
     ending: () => ending,
 
     async waitForFrame(timeoutMs = 30_000) {
@@ -157,6 +168,8 @@ export async function openHandoffPage(
     scroll: (fdy) => send({ type: "scroll", fdy }),
     handback: () => send({ type: "handback" }),
     abort: () => send({ type: "abort" }),
+    approve: () => send({ type: "approve" }),
+    deny: () => send({ type: "deny" }),
 
     close() {
       clearInterval(heartbeat)

--- a/e2e/ui.spec.ts
+++ b/e2e/ui.spec.ts
@@ -34,6 +34,19 @@ import type {
 } from "../src/relay/protocol"
 import type { HandoffMode } from "../src/types"
 
+/**
+ * The browser's WebSocket. This file imports `ws` under the same name for the
+ * agent side, and the two types are not interchangeable.
+ */
+type BrowserSocket = InstanceType<typeof globalThis.WebSocket>
+
+declare global {
+  interface Window {
+    /** Only present when a test installed `captureSockets` before the page. */
+    handraiseSockets?: BrowserSocket[]
+  }
+}
+
 const SERVER_PATH = fileURLToPath(
   new URL("../src/relay/guest/server.js", import.meta.url),
 )
@@ -244,8 +257,25 @@ afterAll(async () => {
   await browser.close()
 })
 
+/**
+ * Keep every WebSocket the page opens, so a test can put one into CLOSING —
+ * the state where an answer is queued while the page has already finished.
+ * Installed before the page script runs, and only where a test asks for it.
+ */
+function captureSockets(): void {
+  const Native = window.WebSocket
+  const sockets: BrowserSocket[] = []
+  window.handraiseSockets = sockets
+  window.WebSocket = class extends Native {
+    constructor(url: string | URL, protocols?: string | string[]) {
+      super(url, protocols)
+      sockets.push(this)
+    }
+  }
+}
+
 /** A relay in `mode`, an agent on it, and the real page in a phone viewport. */
-async function openFixture(mode: HandoffMode): Promise<void> {
+async function openFixture(mode: HandoffMode, capture = false): Promise<void> {
   relay = await startRelay(mode)
   agent = await connectAgent(relay.port)
   consoleErrors = []
@@ -257,15 +287,34 @@ async function openFixture(mode: HandoffMode): Promise<void> {
     if (message.type() === "error") consoleErrors.push(message.text())
   })
   page.on("pageerror", (error) => consoleErrors.push(error.message))
+  if (capture) await page.addInitScript(captureSockets)
   await page.goto(`http://127.0.0.1:${relay.port}/`)
 }
 
-/** Throw the takeover fixture away and come back up in approval mode. */
-async function useApprovalMode(): Promise<void> {
+/** Throw the current fixture away and come back up in `mode`. */
+async function reopenFixture(
+  mode: HandoffMode,
+  capture = false,
+): Promise<void> {
   await page.close()
   agent.close()
   relay.process.kill("SIGKILL")
-  await openFixture("approval")
+  await openFixture(mode, capture)
+}
+
+/**
+ * Close the page's socket and answer in the same breath, so the answer is made
+ * while the socket is CLOSING rather than after it is gone. Returns the socket
+ * state the click actually saw.
+ */
+function answerWhileClosing(buttonId: string): Promise<number> {
+  return page.evaluate((id: string) => {
+    const live = window.handraiseSockets?.at(-1)
+    if (!live) throw new Error("no socket was captured")
+    live.close()
+    document.getElementById(id)?.click()
+    return live.readyState
+  }, buttonId)
 }
 
 beforeEach(async () => {
@@ -1065,8 +1114,8 @@ const APPROVAL_HINT = "Approve needs a hold. Deny is one tap."
 const APPROVAL_HOLD_HINT = "Hold the button to approve"
 
 /** Put the page in approval mode and give it the agent's ask. */
-async function showApproval(): Promise<void> {
-  await useApprovalMode()
+async function showApproval(capture = false): Promise<void> {
+  await reopenFixture("approval", capture)
   agent.send({
     type: "state",
     reason: APPROVAL_REASON,
@@ -1109,6 +1158,24 @@ test("approval mode states the action and offers no way to type", async () => {
     expect(box.height).toBeGreaterThanOrEqual(MIN_TAP_TARGET_PX)
     expect(box.width).toBeGreaterThanOrEqual(MIN_TAP_TARGET_PX)
   }
+
+  // Peers, down to the pixel: the accent marks the action the interface wants,
+  // and an approval has none. Only the gesture differs.
+  const paint = await page.evaluate(() => {
+    const of = (id: string) => {
+      const node = document.getElementById(id)
+      if (!node) throw new Error(`no #${id}`)
+      const style = getComputedStyle(node)
+      return {
+        background: style.backgroundColor,
+        color: style.color,
+        border: style.border,
+        fontWeight: style.fontWeight,
+      }
+    }
+    return { deny: of("deny"), approve: of("approve") }
+  })
+  expect(paint.deny).toEqual(paint.approve)
   expect(consoleErrors).toEqual([])
 })
 
@@ -1181,5 +1248,61 @@ test("an approval ending shows the matching terminal overlay", async () => {
   expect(await page.locator("#overlay-note").textContent()).toBe(
     "The agent has your approval and is continuing. You can close this tab.",
   )
+  expect(consoleErrors).toEqual([])
+})
+
+test("an approval answered while the socket is closing still reaches the agent", async () => {
+  await showApproval(true)
+
+  // The gap this closes: `send` queues the answer because the socket is not
+  // open, `finish` marks the page done, and the socket's own close handler
+  // then used to stop reconnecting — with the answer still in the queue. The
+  // human saw "Denied" and the agent waited out its timeout.
+  const state = await answerWhileClosing("deny")
+  expect(state).toBe(WebSocket.CLOSING)
+
+  await waitForOverlay(page)
+  expect(await page.locator("#overlay-title").textContent()).toBe("Denied")
+  expect(await agent.next()).toEqual({ type: "deny" })
+  expect(consoleErrors).toEqual([])
+}, 20000)
+
+test("a hand back given while the socket is closing still reaches the agent", async () => {
+  // The same hole, on the mode that has had it since 0.3.0.
+  await reopenFixture("takeover", true)
+  await showFrame()
+
+  const state = await answerWhileClosing("handback")
+  expect(state).toBe(WebSocket.CLOSING)
+
+  await waitForOverlay(page)
+  expect(await agent.next()).toEqual({ type: "handback" })
+  expect(consoleErrors).toEqual([])
+}, 20000)
+
+test("one finger pans the approval screenshot and still sends nothing", async () => {
+  await showApproval()
+  await showFrame()
+
+  // At fit there is nowhere to pan to, so zoom in first.
+  const box = await page.locator("#view").boundingBox()
+  if (!box) throw new Error("canvas has no bounding box")
+  const centre = { x: box.x + box.width / 2, y: box.y + box.height / 2 }
+  await page.mouse.dblclick(centre.x, centre.y)
+  await page.waitForTimeout(300)
+  const before = await zoomTransform(page)
+  expect(before.scale).toBeGreaterThan(1.5)
+
+  // The one gesture that was re-purposed rather than disabled: in a takeover
+  // this drag scrolls the remote page, and here it may only move the picture.
+  await page.mouse.move(centre.x, centre.y)
+  await page.mouse.down()
+  await page.mouse.move(centre.x + 60, centre.y + 60, { steps: 6 })
+  await page.mouse.up()
+  await page.waitForTimeout(200)
+
+  const after = await zoomTransform(page)
+  expect(after.tx !== before.tx || after.ty !== before.ty).toBe(true)
+  expect(agent.received).toEqual([])
   expect(consoleErrors).toEqual([])
 })

--- a/e2e/ui.spec.ts
+++ b/e2e/ui.spec.ts
@@ -274,8 +274,17 @@ function captureSockets(): void {
   }
 }
 
-/** A relay in `mode`, an agent on it, and the real page in a phone viewport. */
-async function openFixture(mode: HandoffMode, capture = false): Promise<void> {
+/**
+ * A relay in `mode`, an agent on it, and the real page in a phone viewport.
+ * `capture` records every WebSocket the page opens; `clock` freezes the page's
+ * timers so a test drives the reconnect backoff itself instead of waiting on
+ * it. Both are installed before the page script runs.
+ */
+async function openFixture(
+  mode: HandoffMode,
+  capture = false,
+  clock = false,
+): Promise<void> {
   relay = await startRelay(mode)
   agent = await connectAgent(relay.port)
   consoleErrors = []
@@ -287,6 +296,9 @@ async function openFixture(mode: HandoffMode, capture = false): Promise<void> {
     if (message.type() === "error") consoleErrors.push(message.text())
   })
   page.on("pageerror", (error) => consoleErrors.push(error.message))
+  // Fake time only touches the page, not Playwright's own waits, so a network
+  // close still fires for real while a reconnect timer waits for fastForward.
+  if (clock) await page.clock.install()
   if (capture) await page.addInitScript(captureSockets)
   await page.goto(`http://127.0.0.1:${relay.port}/`)
 }
@@ -295,11 +307,12 @@ async function openFixture(mode: HandoffMode, capture = false): Promise<void> {
 async function reopenFixture(
   mode: HandoffMode,
   capture = false,
+  clock = false,
 ): Promise<void> {
   await page.close()
   agent.close()
   relay.process.kill("SIGKILL")
-  await openFixture(mode, capture)
+  await openFixture(mode, capture, clock)
 }
 
 /**
@@ -1306,3 +1319,71 @@ test("one finger pans the approval screenshot and still sends nothing", async ()
   expect(agent.received).toEqual([])
   expect(consoleErrors).toEqual([])
 })
+
+/** The FLUSH_DEADLINE_MS the page uses, restated so a change to one is a red test. */
+const FLUSH_DEADLINE_MS = 30_000
+
+/** How many WebSockets the page has opened since it loaded (captureSockets). */
+function socketCount(target: Page): Promise<number> {
+  return target.evaluate(() => window.handraiseSockets?.length ?? 0)
+}
+
+test("the reconnect loop gives up flushing once its deadline passes", async () => {
+  // A finished page with a queued answer keeps reconnecting to deliver it. The
+  // backoff caps the wait between attempts, not their number, so against a
+  // relay the agent has already timed out and killed, the tab used to retry a
+  // dead host every 8s forever. The deadline caps the attempts.
+  //
+  // Deterministic, not a 30s wait: the page's clock is frozen, so every
+  // reconnect timer fires only when this test fast-forwards it, and the socket
+  // count is the attempt count.
+  await reopenFixture("takeover", true, true)
+  await showFrame()
+
+  // Kill the relay so every reconnect from here on fails, then wait for the
+  // page to notice its own socket drop (a network event, real even under the
+  // fake clock).
+  agent.close()
+  relay.process.kill("SIGKILL")
+  await page.waitForFunction(() => {
+    const dot = document.getElementById("dot")
+    return dot ? dot.className.includes("waiting") : false
+  })
+
+  // Answer while the socket is down: the message queues, and finish() starts
+  // the flush deadline. One socket has been opened so far — the initial one,
+  // now dead — and no reconnect has fired because its timer is frozen.
+  await page.locator("#handback").click()
+  await waitForOverlay(page)
+  const baseline = await socketCount(page)
+  expect(baseline).toBe(1)
+
+  // Well within the deadline: advance past the first backoff so a reconnect
+  // actually fires. It is the attempt that would flush the answer against a
+  // relay that had come back — proof the loop is still trying.
+  await page.clock.fastForward(2_000)
+  await page.waitForTimeout(150)
+  const during = await socketCount(page)
+  expect(during).toBeGreaterThan(baseline)
+
+  // Cross the deadline. The pending reconnect timer still fires, but connect()
+  // and onclose now see `finished && !stillSending()` and stop.
+  await page.clock.fastForward(FLUSH_DEADLINE_MS)
+  await page.waitForTimeout(150)
+  const atStop = await socketCount(page)
+
+  // Keep advancing: a dead host is no longer retried. The socket count is
+  // frozen — the loop has actually stopped, not merely slowed.
+  await page.clock.fastForward(60_000)
+  await page.waitForTimeout(200)
+  const after = await socketCount(page)
+  expect(after).toBe(atStop)
+
+  // The only console noise here is the browser's own "connection refused" for
+  // each reconnect against the relay this test deliberately killed — the page
+  // handles it (onerror closes the socket). Anything else is a real error.
+  const unexpected = consoleErrors.filter(
+    (line) => !line.includes("net::ERR_CONNECTION_REFUSED"),
+  )
+  expect(unexpected).toEqual([])
+}, 20000)

--- a/e2e/ui.spec.ts
+++ b/e2e/ui.spec.ts
@@ -32,6 +32,7 @@ import type {
   HumanToAgent,
   RelayMessage,
 } from "../src/relay/protocol"
+import type { HandoffMode } from "../src/types"
 
 const SERVER_PATH = fileURLToPath(
   new URL("../src/relay/guest/server.js", import.meta.url),
@@ -96,9 +97,13 @@ function parseMessage(raw: string): RelayMessage {
   return JSON.parse(raw) as RelayMessage
 }
 
-/** Start the real guest server on an OS-assigned port; read the port from its log. */
-function startRelay(): Promise<Relay> {
-  const child = spawn(process.execPath, [SERVER_PATH, "0", AGENT_KEY], {
+/**
+ * Start the real guest server on an OS-assigned port; read the port from its
+ * log. The mode is an argument and not a message: the relay decides what the
+ * human may send, so a test for approval mode has to boot its own relay.
+ */
+function startRelay(mode: HandoffMode = "takeover"): Promise<Relay> {
+  const child = spawn(process.execPath, [SERVER_PATH, "0", AGENT_KEY, mode], {
     stdio: ["ignore", "pipe", "pipe"],
   })
   const logs: string[] = []
@@ -239,8 +244,9 @@ afterAll(async () => {
   await browser.close()
 })
 
-beforeEach(async () => {
-  relay = await startRelay()
+/** A relay in `mode`, an agent on it, and the real page in a phone viewport. */
+async function openFixture(mode: HandoffMode): Promise<void> {
+  relay = await startRelay(mode)
   agent = await connectAgent(relay.port)
   consoleErrors = []
   page = await browser.newPage({
@@ -252,6 +258,18 @@ beforeEach(async () => {
   })
   page.on("pageerror", (error) => consoleErrors.push(error.message))
   await page.goto(`http://127.0.0.1:${relay.port}/`)
+}
+
+/** Throw the takeover fixture away and come back up in approval mode. */
+async function useApprovalMode(): Promise<void> {
+  await page.close()
+  agent.close()
+  relay.process.kill("SIGKILL")
+  await openFixture("approval")
+}
+
+beforeEach(async () => {
+  await openFixture("takeover")
 })
 
 afterEach(async () => {
@@ -1033,3 +1051,135 @@ test("the page reconnects after its socket drops, with a single live human", asy
   expect(openHumans(relay)).toBe(1)
   expect(consoleErrors).toEqual([])
 }, 20000)
+
+// --- Approval mode --------------------------------------------------------
+//
+// A different job on the same page: the human is not driving the browser, they
+// are answering one question about one screenshot. The tests below assert the
+// two halves of that — the screen says what is about to happen, and nothing the
+// human touches can reach the remote page.
+
+const APPROVAL_REASON = "Agent wants to submit this payment"
+const APPROVAL_ACTION = "Submit $12,430 vendor payment to Acme GmbH"
+const APPROVAL_HINT = "Approve needs a hold. Deny is one tap."
+const APPROVAL_HOLD_HINT = "Hold the button to approve"
+
+/** Put the page in approval mode and give it the agent's ask. */
+async function showApproval(): Promise<void> {
+  await useApprovalMode()
+  agent.send({
+    type: "state",
+    reason: APPROVAL_REASON,
+    action: APPROVAL_ACTION,
+  })
+  await page.waitForFunction(
+    (action: string) =>
+      document.getElementById("action")?.textContent === action,
+    APPROVAL_ACTION,
+  )
+}
+
+test("approval mode states the action and offers no way to type", async () => {
+  await showApproval()
+
+  expect(await page.locator("#reason").textContent()).toBe(APPROVAL_REASON)
+  expect(await page.locator(".eyebrow").textContent()).toBe(
+    "handraise · an agent needs your approval",
+  )
+  // The action is the sentence the decision is made on, so it is the largest
+  // type on the page — larger than the reason above it.
+  const sizes = await page.evaluate(() => {
+    const size = (id: string): number => {
+      const node = document.getElementById(id)
+      if (!node) throw new Error(`no #${id}`)
+      return Number.parseFloat(getComputedStyle(node).fontSize)
+    }
+    return { action: size("action"), reason: size("reason") }
+  })
+  expect(sizes.action).toBeGreaterThan(sizes.reason)
+
+  // No keyboard, no key bar: there is nothing on this screen to type into.
+  expect(await page.locator("#kbd").isVisible()).toBe(false)
+  expect(await page.locator(".keys").isVisible()).toBe(false)
+  expect(await page.locator("#hint").textContent()).toBe(APPROVAL_HINT)
+
+  for (const id of ["#deny", "#approve"]) {
+    const box = await page.locator(id).boundingBox()
+    if (!box) throw new Error(`${id} has no bounding box`)
+    expect(box.height).toBeGreaterThanOrEqual(MIN_TAP_TARGET_PX)
+    expect(box.width).toBeGreaterThanOrEqual(MIN_TAP_TARGET_PX)
+  }
+  expect(consoleErrors).toEqual([])
+})
+
+test("deny is one tap and says so on the way out", async () => {
+  await showApproval()
+
+  await page.locator("#deny").click()
+  expect(await agent.next()).toEqual({ type: "deny" })
+
+  await waitForOverlay(page)
+  expect(await page.locator("#overlay-title").textContent()).toBe("Denied")
+  expect(await page.locator("#overlay-note").textContent()).toBe(
+    "The agent has been told not to do it. You can close this tab.",
+  )
+  await page.waitForTimeout(300)
+  expect(countOf("deny")).toBe(1)
+  expect(consoleErrors).toEqual([])
+})
+
+test("approve takes the hold, and a short press only explains", async () => {
+  await showApproval()
+
+  // The inversion of takeover mode: here the irreversible answer is yes, so
+  // yes is the one that costs a hold.
+  await pressAndHold("#approve", 300)
+  await page.waitForTimeout(400)
+  expect(countOf("approve")).toBe(0)
+  expect(await page.locator("#overlay").isHidden()).toBe(true)
+  expect(await page.locator("#hint").textContent()).toBe(APPROVAL_HOLD_HINT)
+
+  await pressAndHold("#approve", 900)
+  expect(await agent.next()).toEqual({ type: "approve" })
+  await waitForOverlay(page)
+  await page.waitForTimeout(400)
+  expect(countOf("approve")).toBe(1)
+  expect(await page.locator("#overlay-title").textContent()).toBe("Approved")
+  expect(consoleErrors).toEqual([])
+})
+
+test("the screenshot zooms but nothing the human touches reaches the page", async () => {
+  await showApproval()
+  await showFrame()
+
+  const box = await page.locator("#view").boundingBox()
+  if (!box) throw new Error("canvas has no bounding box")
+  const centre = { x: box.width / 2, y: box.height / 2 }
+
+  await page.locator("#view").click({ position: centre })
+  await page.mouse.wheel(0, 200)
+  await page.waitForTimeout(300)
+  // Approval injects no input at all — not a tap, not a scroll, not a key.
+  expect(agent.received).toEqual([])
+
+  // It is still a screenshot of a page nobody can read at 29%, so the zoom
+  // gestures stay: a double tap magnifies it.
+  await page.locator("#view").dblclick({ position: centre })
+  await page.waitForTimeout(300)
+  expect((await zoomTransform(page)).scale).toBeGreaterThan(1.5)
+  expect(agent.received).toEqual([])
+  expect(consoleErrors).toEqual([])
+})
+
+test("an approval ending shows the matching terminal overlay", async () => {
+  await showApproval()
+
+  agent.send({ type: "ended", outcome: "approved" })
+
+  await waitForOverlay(page)
+  expect(await page.locator("#overlay-title").textContent()).toBe("Approved")
+  expect(await page.locator("#overlay-note").textContent()).toBe(
+    "The agent has your approval and is continuing. You can close this tab.",
+  )
+  expect(consoleErrors).toEqual([])
+})

--- a/src/core/handoff.test.ts
+++ b/src/core/handoff.test.ts
@@ -13,15 +13,16 @@
 import { afterEach, expect, test } from "bun:test"
 import { spawn } from "node:child_process"
 import { readFileSync } from "node:fs"
+import type { AddressInfo } from "node:net"
 import { fileURLToPath } from "node:url"
 import type { Browser, BrowserContext, CDPSession, Page } from "playwright-core"
-import WebSocket from "ws"
+import WebSocket, { WebSocketServer } from "ws"
 
 import type { HandoffEvent } from "../events"
 import { noopLogger } from "../logger"
 import type { RelayMessage } from "../relay/protocol"
-import type { HandoffMode, StorageState } from "../types"
-import { runHandoff } from "./raise-hand"
+import type { HandoffMode, RaiseHandOptions, StorageState } from "../types"
+import { raiseHand, runHandoff } from "./raise-hand"
 import type { ScreencastFrame } from "./screencast"
 
 const SERVER_PATH = fileURLToPath(
@@ -145,14 +146,25 @@ function fakeCdp(): FakeCdp {
 
 const STORAGE: StorageState = { cookies: [], origins: [] }
 
+/**
+ * A gateway that cannot answer. The guards under test throw before any client
+ * is built; this is only here so that a regression fails against a closed port
+ * rather than creating a sandbox with whatever key the environment holds.
+ */
+const CLOSED_PORT = "http://127.0.0.1:1"
+
 /** A real 800x500 JPEG, so the approval frame's metadata is parsed, not guessed. */
 const SAMPLE_JPEG = readFileSync(
   fileURLToPath(new URL("./fixtures/sample-frame.jpg", import.meta.url)),
 )
 const VIEWPORT = { width: 1280, height: 800 }
 
+/** CDP sessions opened on the fake page since the last reset. */
+let cdpSessions = 0
+
 /** A page whose context yields the fake CDP session and a live fake browser. */
 function fakePage(cdp: CDPSession): Page {
+  cdpSessions = 0
   let browser: Browser
   const browserPartial: Partial<Browser> = {
     // SAFETY: registration the test never fires; the returned emitter is only
@@ -166,7 +178,10 @@ function fakePage(cdp: CDPSession): Page {
   browser = browserPartial as Browser
   const contextPartial: Partial<BrowserContext> = {
     browser: () => browser,
-    newCDPSession: async () => cdp,
+    newCDPSession: async () => {
+      cdpSessions += 1
+      return cdp
+    },
     storageState: async () => STORAGE,
   }
   // SAFETY: runHandoff drives only browser/newCDPSession/storageState here.
@@ -324,6 +339,7 @@ test("an approval handoff sends one screenshot and settles on approve", async ()
     human.inbox.filter((message) => message.type === "frame"),
   ).toHaveLength(1)
   // No CDP session is opened at all: no screencast, no input, no focus probe.
+  expect(cdpSessions).toBe(0)
   expect(cdp.calls).toEqual([])
 
   const event = events[0]
@@ -331,6 +347,8 @@ test("an approval handoff sends one screenshot and settles on approve", async ()
   expect(events).toHaveLength(1)
   expect(event.mode).toBe("approval")
   expect(event.outcome).toBe("approved")
+  // One frame per connection, and this handoff had exactly one connection.
+  expect(event.reconnects).toBe(0)
   expect(event.framesSent).toBe(1)
   expect(event.bytesSent).toBeGreaterThan(0)
   expect(event.inputsApplied).toBe(0)
@@ -407,4 +425,131 @@ test("a denied approval reports denied", async () => {
       (message) => message.type === "ended" && message.outcome === "denied",
     ),
   )
+})
+
+/**
+ * A bare WebSocket server standing in for the relay, which cuts every
+ * connection the moment it has received a frame.
+ *
+ * The real relay is the right peer for routing; it is the wrong one here,
+ * because what is under test is what the agent puts on the wire *after* its
+ * handoff is over. Terminating on every frame means a connection that carries
+ * a frame can never also carry the ending — so an ending that arrives at all
+ * proves the frame was withheld.
+ */
+interface FakeRelay {
+  port: number
+  /** Messages received, split by the connection they arrived on. */
+  connections: RelayMessage[][]
+}
+
+async function startFrameCuttingRelay(): Promise<FakeRelay> {
+  const server = new WebSocketServer({ port: 0, host: "127.0.0.1" })
+  const connections: RelayMessage[][] = []
+  const sockets: WebSocket[] = []
+
+  server.on("connection", (socket: WebSocket) => {
+    const inbox: RelayMessage[] = []
+    connections.push(inbox)
+    sockets.push(socket)
+    socket.on("message", (data: Buffer) => {
+      // SAFETY: the only writer on this socket is the handoff under test.
+      const message = JSON.parse(data.toString("utf8")) as RelayMessage
+      inbox.push(message)
+      if (message.type === "frame") socket.terminate()
+    })
+  })
+  await new Promise<void>((resolve) =>
+    server.once("listening", () => resolve()),
+  )
+  cleanups.push(() => {
+    for (const socket of sockets) socket.terminate()
+    server.close()
+  })
+
+  const address = server.address()
+  // SAFETY: the server listens on a TCP port; `address()` only returns a
+  // string for a unix socket.
+  const port = (address as AddressInfo).port
+  return { port, connections }
+}
+
+test("the approval screenshot is not re-published once the handoff is over", async () => {
+  // The relay scrubs its replay buffer when a handoff ends, so that whoever
+  // opens the link next cannot see the page. A reconnect during teardown that
+  // re-sent the screenshot would undo exactly that.
+  const relay = await startFrameCuttingRelay()
+  const cdp = fakeCdp()
+
+  const handoff = runHandoff({
+    page: fakePage(cdp.cdp),
+    agentWsUrl: `ws://127.0.0.1:${relay.port}/`,
+    options: {
+      mode: "approval",
+      reason: "Agent wants to submit this payment",
+      action: "Submit $12,430 vendor payment to Acme GmbH",
+      logger: noopLogger,
+    },
+    // Long enough for a reconnect or two while the "human" decides, short
+    // enough that the ending falls into one of them.
+    timeoutMs: 1200,
+    handoffId: "approval-reconnect",
+    relayColdStartMs: 3,
+    logger: noopLogger,
+  })
+
+  const end = await handoff
+  expect(end.outcome).toBe("timeout")
+  // `raiseHand` does not wait for the relay to read its ending, so this test
+  // has to.
+  await until("the ending to reach the relay", () =>
+    relay.connections.some((inbox) =>
+      inbox.some((message) => message.type === "ended"),
+    ),
+  )
+
+  // Every connection that carried a frame was cut, so the one that carried the
+  // ending is one the agent chose not to re-send the screenshot on.
+  const ending = relay.connections.find((inbox) =>
+    inbox.some((message) => message.type === "ended"),
+  )
+  expect(ending).toBeDefined()
+  expect(ending?.filter((message) => message.type === "frame")).toEqual([])
+  // It really did reconnect: the first connection was cut on the frame.
+  expect(relay.connections.length).toBeGreaterThan(1)
+}, 20000)
+
+test("an approval with a blank action is refused before a relay is started", async () => {
+  // The tool guards this for the model; the library has to guard it for every
+  // caller, and here is the one place raiseHand may still throw — no URL
+  // exists yet, so nobody has been asked for anything.
+  const asking = raiseHand(fakePage(fakeCdp().cdp), {
+    mode: "approval",
+    reason: "The agent may not move money without a human",
+    action: "   ",
+    // bun loads .env, so a key is usually in the environment when this runs.
+    // A closed port is what keeps a regression here from creating a real
+    // sandbox instead of failing.
+    baseUrl: CLOSED_PORT,
+    logger: noopLogger,
+  })
+
+  await expect(asking).rejects.toThrow(/needs a non-empty `action`/)
+})
+
+test("an unknown mode is refused before anything is created", async () => {
+  // `HandoffMode` closes this for TypeScript callers. This package ships as
+  // JavaScript, the mode reaches the relay's command line, and an unknown one
+  // would otherwise fall open as a takeover — with a live input path.
+  // `Object.assign` is how a test written in TypeScript produces the value a
+  // JavaScript caller would pass.
+  const options: RaiseHandOptions = {
+    reason: "The agent may not move money without a human",
+    baseUrl: CLOSED_PORT,
+    logger: noopLogger,
+  }
+  Object.assign(options, { mode: "approval; touch /tmp/handraise-pwned" })
+
+  const asking = raiseHand(fakePage(fakeCdp().cdp), options)
+  await expect(asking).rejects.toThrow(/unknown mode/)
 })

--- a/src/core/handoff.test.ts
+++ b/src/core/handoff.test.ts
@@ -12,6 +12,7 @@
  */
 import { afterEach, expect, test } from "bun:test"
 import { spawn } from "node:child_process"
+import { readFileSync } from "node:fs"
 import { fileURLToPath } from "node:url"
 import type { Browser, BrowserContext, CDPSession, Page } from "playwright-core"
 import WebSocket from "ws"
@@ -19,7 +20,7 @@ import WebSocket from "ws"
 import type { HandoffEvent } from "../events"
 import { noopLogger } from "../logger"
 import type { RelayMessage } from "../relay/protocol"
-import type { StorageState } from "../types"
+import type { HandoffMode, StorageState } from "../types"
 import { runHandoff } from "./raise-hand"
 import type { ScreencastFrame } from "./screencast"
 
@@ -55,8 +56,8 @@ async function until(
 }
 
 /** The real relay on an OS-assigned port, read back out of its startup log. */
-function startRelayProcess(): Promise<number> {
-  const child = spawn(process.execPath, [SERVER_PATH, "0"], {
+function startRelayProcess(mode: HandoffMode = "takeover"): Promise<number> {
+  const child = spawn(process.execPath, [SERVER_PATH, "0", "", mode], {
     stdio: ["ignore", "pipe", "pipe"],
   })
   cleanups.push(() => child.kill("SIGKILL"))
@@ -144,6 +145,12 @@ function fakeCdp(): FakeCdp {
 
 const STORAGE: StorageState = { cookies: [], origins: [] }
 
+/** A real 800x500 JPEG, so the approval frame's metadata is parsed, not guessed. */
+const SAMPLE_JPEG = readFileSync(
+  fileURLToPath(new URL("./fixtures/sample-frame.jpg", import.meta.url)),
+)
+const VIEWPORT = { width: 1280, height: 800 }
+
 /** A page whose context yields the fake CDP session and a live fake browser. */
 function fakePage(cdp: CDPSession): Page {
   let browser: Browser
@@ -167,12 +174,17 @@ function fakePage(cdp: CDPSession): Page {
   let page: Page
   const pagePartial: Partial<Page> = {
     context: () => context,
+    // SAFETY: approval mode calls screenshot() for its one frame and reads the
+    // viewport for that frame's metadata; neither result is used as anything else.
+    screenshot: (async () => SAMPLE_JPEG) as Page["screenshot"],
+    viewportSize: () => VIEWPORT,
     // SAFETY: as the browser's, above — an unused chaining emitter.
     once: (() => page) as Page["once"],
     // SAFETY: as `once`, above — an unused chaining emitter.
     off: (() => page) as Page["off"],
   }
-  // SAFETY: runHandoff uses only context/once/off on the page.
+  // SAFETY: runHandoff uses only context/once/off, plus screenshot and
+  // viewportSize in approval mode, on the page.
   page = pagePartial as Page
   return page
 }
@@ -269,4 +281,130 @@ test("a throwing onEvent callback does not break the handoff", async () => {
   // The handoff still settles cleanly despite the throwing callback.
   const end = await handoff
   expect(end.outcome).toBe("aborted")
+})
+
+test("an approval handoff sends one screenshot and settles on approve", async () => {
+  const port = await startRelayProcess("approval")
+  const human = await connectHuman(port)
+  const cdp = fakeCdp()
+  const events: HandoffEvent[] = []
+
+  const handoff = runHandoff({
+    page: fakePage(cdp.cdp),
+    agentWsUrl: `ws://127.0.0.1:${port}/ws?role=agent`,
+    options: {
+      mode: "approval",
+      reason: "Agent wants to submit this payment",
+      action: "Submit $12,430 vendor payment to Acme GmbH",
+      logger: noopLogger,
+      onEvent: (event) => events.push(event),
+    },
+    timeoutMs: 5000,
+    handoffId: "approval-handoff",
+    relayColdStartMs: 42,
+    logger: noopLogger,
+  })
+
+  await until("the phone to see the action", () =>
+    human.inbox.some(
+      (message) => message.type === "state" && message.action !== undefined,
+    ),
+  )
+  await until("the phone to see the screenshot", () =>
+    human.inbox.some((message) => message.type === "frame"),
+  )
+
+  human.send({ type: "approve" })
+  const end = await handoff
+
+  expect(end.outcome).toBe("approved")
+  // One screenshot, not a stream: the approval never starts a screencast, so
+  // nothing arrives after the first frame either.
+  expect(
+    human.inbox.filter((message) => message.type === "frame"),
+  ).toHaveLength(1)
+  // No CDP session is opened at all: no screencast, no input, no focus probe.
+  expect(cdp.calls).toEqual([])
+
+  const event = events[0]
+  if (!event) throw new Error("no event")
+  expect(events).toHaveLength(1)
+  expect(event.mode).toBe("approval")
+  expect(event.outcome).toBe("approved")
+  expect(event.framesSent).toBe(1)
+  expect(event.bytesSent).toBeGreaterThan(0)
+  expect(event.inputsApplied).toBe(0)
+  // The human never touched the page, so there is no new state to capture.
+  expect(event.storageStateCaptured).toBe(false)
+  expect(end.storageState).toBeUndefined()
+})
+
+test("an approval handoff ignores takeover messages that reach it anyway", async () => {
+  // A takeover relay in front of an approval handoff is the mismatch the agent
+  // has to survive on its own: an older or tampered relay routes tap and
+  // handback, and neither may do anything here.
+  const port = await startRelayProcess("takeover")
+  const human = await connectHuman(port)
+  const cdp = fakeCdp()
+
+  const handoff = runHandoff({
+    page: fakePage(cdp.cdp),
+    agentWsUrl: `ws://127.0.0.1:${port}/ws?role=agent`,
+    options: {
+      mode: "approval",
+      reason: "Agent wants to submit this payment",
+      action: "Submit $12,430 vendor payment to Acme GmbH",
+      logger: noopLogger,
+    },
+    timeoutMs: 1500,
+    logger: noopLogger,
+    handoffId: "approval-mismatch",
+    relayColdStartMs: 7,
+  })
+
+  await until("the phone to see the screenshot", () =>
+    human.inbox.some((message) => message.type === "frame"),
+  )
+  human.send({ type: "tap", fx: 400, fy: 250 })
+  human.send({ type: "char", ch: "9" })
+  human.send({ type: "handback" })
+
+  // Not "resolved": a handback is not an approval, so the wait runs out.
+  const end = await handoff
+  expect(end.outcome).toBe("timeout")
+  expect(cdp.calls).toEqual([])
+})
+
+test("a denied approval reports denied", async () => {
+  const port = await startRelayProcess("approval")
+  const human = await connectHuman(port)
+  const cdp = fakeCdp()
+
+  const handoff = runHandoff({
+    page: fakePage(cdp.cdp),
+    agentWsUrl: `ws://127.0.0.1:${port}/ws?role=agent`,
+    options: {
+      mode: "approval",
+      reason: "Agent wants to delete the production bucket",
+      action: "Delete s3://prod-invoices",
+      logger: noopLogger,
+    },
+    timeoutMs: 5000,
+    handoffId: "approval-denied",
+    relayColdStartMs: 9,
+    logger: noopLogger,
+  })
+
+  await until("the phone to see the screenshot", () =>
+    human.inbox.some((message) => message.type === "frame"),
+  )
+  human.send({ type: "deny" })
+
+  const end = await handoff
+  expect(end.outcome).toBe("denied")
+  await until("the phone to be told how it ended", () =>
+    human.inbox.some(
+      (message) => message.type === "ended" && message.outcome === "denied",
+    ),
+  )
 })

--- a/src/core/raise-hand.ts
+++ b/src/core/raise-hand.ts
@@ -201,10 +201,18 @@ export async function runHandoff(run: HandoffRun): Promise<HandoffEnd> {
   let firstFrameMs: number | undefined
   let firstError: string | undefined
 
+  // Set by the first settle, on every path — a human answer, the timeout, a
+  // dead session. Nothing about the page may go on the wire after it: the
+  // relay scrubs its replay buffers when a handoff ends, and a reconnect that
+  // re-sent the screenshot would undo exactly that scrubbing.
+  let over = false
   let settle: (outcome: HandoffOutcome) => void = () => undefined
   // A promise resolves once; that is where "settled exactly once" comes from.
   const finished = new Promise<HandoffOutcome>((resolve) => {
-    settle = resolve
+    settle = (outcome) => {
+      over = true
+      resolve(outcome)
+    }
   })
 
   const browser = page.context().browser()
@@ -280,15 +288,18 @@ export async function runHandoff(run: HandoffRun): Promise<HandoffEnd> {
   }
 
   // The approval's single screenshot, kept so a reconnect can put it back on
-  // the wire. A cast would simply send the next frame; this one has no next.
+  // the wire. A cast would simply send the next frame; this one has no next,
+  // which is why `framesSent` counts one per connection and not one per
+  // handoff — every one of them really did go over the wire.
   let approvalFrame: ApprovalFrame | null = null
   const sendApprovalFrame = async (): Promise<void> => {
     const shot = approvalFrame
     // `send` resolves without sending while the socket is down, which is right
     // for a cast and wrong for the only frame there is: skip it, and let the
-    // reconnect's `onOpen` be the one that delivers it (and counts it).
+    // reconnect's `onOpen` be the one that delivers it (and counts it). Once
+    // the handoff is over there is nothing to deliver at all.
     const live = link
-    if (!shot || !live?.isOpen()) return
+    if (!shot || over || !live?.isOpen()) return
     await live.send({ type: "frame", data: shot.data, meta: shot.meta })
     framesSent += 1
     bytesSent += shot.data.length
@@ -409,12 +420,48 @@ export async function runHandoff(run: HandoffRun): Promise<HandoffEnd> {
   return { outcome: finalOutcome, storageState }
 }
 
+/** The two modes, as a runtime value. */
+const MODES = new Set<string>(["takeover", "approval"])
+
+/**
+ * Check the mode and, in approval mode, that there is an action to decide on;
+ * return the mode. Everything `raiseHand` refuses to start a handoff for is
+ * here, and here is the one place it may throw: no URL exists yet, so nobody
+ * has been asked for anything and the caller can retry or give up cleanly.
+ *
+ * The types close both of these for TypeScript callers. This package is
+ * published as JavaScript as well, the mode ends up on the relay's command
+ * line, and an approval with no action puts a blank question on a phone.
+ */
+function checkedMode(options: RaiseHandOptions): HandoffMode {
+  const mode = options.mode ?? "takeover"
+  if (!MODES.has(mode)) {
+    throw new Error(
+      `handraise: unknown mode ${JSON.stringify(mode)} — it must be "takeover" or "approval".`,
+    )
+  }
+  // String(): a JavaScript caller can leave `action` out entirely, and a
+  // TypeError from reading `.trim()` of undefined is not an answer.
+  if (
+    options.mode === "approval" &&
+    String(options.action ?? "").trim() === ""
+  ) {
+    throw new Error(
+      'handraise: mode "approval" needs a non-empty `action` — it is the step the human says yes or no to, and the phone shows it as the decision. Without it a human is asked to approve a blank line.',
+    )
+  }
+  // SAFETY: `MODES` holds exactly the two members of HandoffMode, so a value
+  // that passed the check above is one of them.
+  return mode as HandoffMode
+}
+
 /** See `RaiseHand` in ../types.ts for the contract. */
 export async function raiseHand(
   page: Page,
   options: RaiseHandOptions,
 ): Promise<HandoffResult> {
   const logger = options.logger ?? quietLogger
+  const mode = checkedMode(options)
   const apiKey = options.apiKey ?? process.env.SOLARI_API_KEY
   if (!apiKey) {
     throw new Error(
@@ -423,9 +470,6 @@ export async function raiseHand(
   }
 
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
-  // Throwing here is allowed and correct: no URL exists yet, so no human has
-  // been asked for anything and the caller can retry or give up cleanly.
-  const mode: HandoffMode = options.mode ?? "takeover"
   const relay = await startRelay(
     options.baseUrl
       ? {

--- a/src/core/raise-hand.ts
+++ b/src/core/raise-hand.ts
@@ -22,6 +22,7 @@ import { printHandoffQr } from "../qr"
 import { startRelay } from "../relay/deploy"
 import type { AgentToHuman, HumanToAgent } from "../relay/protocol"
 import type {
+  HandoffMode,
   HandoffOutcome,
   HandoffResult,
   RaiseHandOptions,
@@ -31,6 +32,7 @@ import { notifyWebhook } from "../webhook"
 import { NO_FOCUS, probeFocus } from "./focus"
 import { createInputTarget } from "./input"
 import { DEFAULT_PROFILE, type FramePump, startFramePump } from "./screencast"
+import { type ApprovalFrame, captureApprovalFrame } from "./snapshot"
 import { connectRelay, type RelayConnection } from "./socket"
 
 /**
@@ -90,6 +92,35 @@ function endedMessage(outcome: HandoffOutcome): AgentToHuman {
   return { type: "ended", outcome }
 }
 
+/** What the human is looking at, replayed on every (re)connect. */
+function stateMessage(options: RaiseHandOptions): AgentToHuman {
+  if (options.mode === "approval") {
+    return { type: "state", reason: options.reason, action: options.action }
+  }
+  return { type: "state", reason: options.reason }
+}
+
+/**
+ * The human message that ends this mode, and what it means to the caller.
+ *
+ * Each mode answers to its own two messages and ignores the other pair. The
+ * relay refuses to route them in the first place; this is the second lock, for
+ * the case where the relay is not the one this version shipped.
+ */
+function endingFor(
+  mode: HandoffMode,
+  type: HumanToAgent["type"],
+): HandoffOutcome | null {
+  if (mode === "approval") {
+    if (type === "approve") return "approved"
+    if (type === "deny") return "denied"
+    return null
+  }
+  if (type === "handback") return "resolved"
+  if (type === "abort") return "aborted"
+  return null
+}
+
 /**
  * A dead Solari browser session has no error code and no status — the only
  * stable marker is this substring (docs/measurements/04-browser-session-lifetime.md §3). It is a fallback:
@@ -115,6 +146,25 @@ export interface HandoffRun {
   /** Measured by `startRelay()` and mirrored into the event. */
   relayColdStartMs: number
   logger: Logger
+}
+
+/**
+ * Start the live cast for a takeover, wired to the relay socket.
+ *
+ * The frame is written to the relay before it is acknowledged to Chromium, so
+ * the cast paces itself to the phone's link (see screencast.ts). `onSent` runs
+ * after the write resolves, which is what makes the counters truthful.
+ */
+async function startTakeoverCast(
+  cdp: CDPSession,
+  connection: RelayConnection,
+  onSent: (data: string) => void,
+): Promise<FramePump> {
+  return startFramePump(cdp, DEFAULT_PROFILE, async (data, meta) => {
+    // The ack that paces the cast waits on this write. See screencast.ts.
+    await connection.send({ type: "frame", data, meta })
+    onSent(data)
+  })
 }
 
 /**
@@ -144,6 +194,7 @@ function emitHandoffEvent(
  */
 export async function runHandoff(run: HandoffRun): Promise<HandoffEnd> {
   const { page, agentWsUrl, options, timeoutMs, logger } = run
+  const mode: HandoffMode = options.mode ?? "takeover"
   const startedAt = Date.now()
   let framesSent = 0
   let bytesSent = 0
@@ -202,19 +253,16 @@ export async function runHandoff(run: HandoffRun): Promise<HandoffEnd> {
   }
 
   const onHuman = (message: HumanToAgent): void => {
-    if (message.type === "handback") {
+    const ending = endingFor(mode, message.type)
+    if (ending) {
       terminal = true
-      settle("resolved")
-      return
-    }
-    if (message.type === "abort") {
-      terminal = true
-      settle("aborted")
+      settle(ending)
       return
     }
     // Once a terminal message has arrived the page is being handed back or
-    // abandoned, so no further input may run against it.
-    if (terminal) return
+    // abandoned, so no further input may run against it. An approval never
+    // injects anything at all: the human is answering, not driving.
+    if (terminal || mode === "approval") return
     // Input can only be mapped once a frame has defined the coordinate space.
     const meta = pump?.lastMeta()
     if (!meta || !input) return
@@ -231,6 +279,22 @@ export async function runHandoff(run: HandoffRun): Promise<HandoffEnd> {
       })
   }
 
+  // The approval's single screenshot, kept so a reconnect can put it back on
+  // the wire. A cast would simply send the next frame; this one has no next.
+  let approvalFrame: ApprovalFrame | null = null
+  const sendApprovalFrame = async (): Promise<void> => {
+    const shot = approvalFrame
+    // `send` resolves without sending while the socket is down, which is right
+    // for a cast and wrong for the only frame there is: skip it, and let the
+    // reconnect's `onOpen` be the one that delivers it (and counts it).
+    const live = link
+    if (!shot || !live?.isOpen()) return
+    await live.send({ type: "frame", data: shot.data, meta: shot.meta })
+    framesSent += 1
+    bytesSent += shot.data.length
+    if (firstFrameMs === undefined) firstFrameMs = Date.now() - startedAt
+  }
+
   const connection = connectRelay({
     url: agentWsUrl,
     onMessage: onHuman,
@@ -238,29 +302,37 @@ export async function runHandoff(run: HandoffRun): Promise<HandoffEnd> {
     // every reconnect costs one small message and covers the case where the
     // relay restarted underneath us.
     onOpen: () => {
-      void link?.send({ type: "state", reason: options.reason })
+      void link?.send(stateMessage(options))
+      void sendApprovalFrame()
     },
   })
   link = connection
 
   try {
-    cdp = await page.context().newCDPSession(page)
-    input = createInputTarget(cdp)
-    pump = await startFramePump(cdp, DEFAULT_PROFILE, async (data, meta) => {
-      // The ack that paces the cast waits on this write. See screencast.ts.
-      await connection.send({ type: "frame", data, meta })
-      // Counted with the same "send resolved" semantics as pump.frameCount():
-      // a base64 payload is ASCII, so its char length is its byte length.
-      framesSent += 1
-      bytesSent += data.length
-      if (firstFrameMs === undefined) {
-        firstFrameMs = Date.now() - startedAt
-        // The phone now has a picture to draw on. If the agent left a field
-        // focused — the usual case, it got stuck on a login form — the human
-        // sees the ring on the first frame rather than after their first tap.
-        refreshFocus()
-      }
-    })
+    if (mode === "approval") {
+      // One screenshot and nothing else: no CDP session, no screencast, no
+      // focus probe. The page the human decides on is the page as the agent
+      // left it, and it is still that page afterwards.
+      approvalFrame = await captureApprovalFrame(page)
+      await sendApprovalFrame()
+    } else {
+      cdp = await page.context().newCDPSession(page)
+      input = createInputTarget(cdp)
+      pump = await startTakeoverCast(cdp, connection, (data) => {
+        // Counted with the same "send resolved" semantics as
+        // pump.frameCount(): a base64 payload is ASCII, so its char length is
+        // its byte length.
+        framesSent += 1
+        bytesSent += data.length
+        if (firstFrameMs === undefined) {
+          firstFrameMs = Date.now() - startedAt
+          // The phone now has a picture to draw on. If the agent left a field
+          // focused — the usual case, it got stuck on a login form — the human
+          // sees the ring on the first frame rather than after their first tap.
+          refreshFocus()
+        }
+      })
+    }
   } catch (error) {
     firstError = String(error)
     logger.error("live_view_start_failed", { error: firstError })
@@ -317,6 +389,7 @@ export async function runHandoff(run: HandoffRun): Promise<HandoffEnd> {
   const event: HandoffEvent = {
     handoffId: run.handoffId,
     outcome: finalOutcome,
+    mode,
     reason: options.reason,
     timeoutMs,
     durationMs,
@@ -352,15 +425,17 @@ export async function raiseHand(
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
   // Throwing here is allowed and correct: no URL exists yet, so no human has
   // been asked for anything and the caller can retry or give up cleanly.
+  const mode: HandoffMode = options.mode ?? "takeover"
   const relay = await startRelay(
     options.baseUrl
       ? {
           apiKey,
+          mode,
           timeoutMs: timeoutMs + RELAY_SLACK_MS,
           baseUrl: options.baseUrl,
           logger,
         }
-      : { apiKey, timeoutMs: timeoutMs + RELAY_SLACK_MS, logger },
+      : { apiKey, mode, timeoutMs: timeoutMs + RELAY_SLACK_MS, logger },
   )
 
   const startedAt = Date.now()
@@ -374,7 +449,13 @@ export async function raiseHand(
     } catch (error) {
       logger.warn("on_url_threw", { error: String(error) })
     }
-    if (options.qr !== false) printHandoffQr(relay.humanUrl, options.reason)
+    // In approval mode the action is the decision, so the terminal line the
+    // operator reads carries it next to the reason.
+    const headline =
+      options.mode === "approval"
+        ? `${options.reason} — ${options.action}`
+        : options.reason
+    if (options.qr !== false) printHandoffQr(relay.humanUrl, headline)
     if (options.webhookUrl) {
       // Deliberately not awaited: the human may already be scanning the QR
       // code while a slow Slack endpoint is still thinking.

--- a/src/core/snapshot.ts
+++ b/src/core/snapshot.ts
@@ -1,0 +1,62 @@
+/**
+ * The one frame an approval sends.
+ *
+ * Approval mode asks a question about a moment, not about a session: the human
+ * decides on what the page looked like when the agent stopped. So there is no
+ * screencast, no ack loop and no CDP session here — a single JPEG, taken the
+ * way Playwright takes any screenshot.
+ *
+ * It is deliberately not scaled to the screencast's 800px profile. One frame
+ * costs what a tenth of a second of cast costs, and the human is reading an
+ * amount and a payee off it, so the pixels are worth more than the bytes.
+ */
+import type { Page } from "playwright-core"
+
+import type { FrameMeta } from "../relay/protocol"
+import { jpegSize } from "./screencast"
+
+/**
+ * Same quality as the live cast (docs/measurements/02-cdp-screencast.md).
+ * Legible for reading a form back, and small enough for a chat message: a
+ * 1280x800 viewport lands well inside a megabyte.
+ */
+export const APPROVAL_QUALITY = 60
+
+/** The viewport assumed when the page cannot report one (a headless default). */
+const FALLBACK_VIEWPORT = { width: 1280, height: 800 }
+
+export interface ApprovalFrame {
+  /** Base64 JPEG, in the same shape a screencast frame arrives in. */
+  data: string
+  meta: FrameMeta
+}
+
+/**
+ * Take the screenshot the human decides on.
+ *
+ * The metadata is filled the same way the pump fills it, so the phone's
+ * letterbox and zoom maths cannot tell the two kinds of frame apart:
+ * `deviceWidth`/`deviceHeight` are the page's CSS viewport and the jpeg size
+ * is read out of the JPEG itself.
+ */
+export async function captureApprovalFrame(page: Page): Promise<ApprovalFrame> {
+  const shot = await page.screenshot({
+    type: "jpeg",
+    quality: APPROVAL_QUALITY,
+  })
+  const viewport = page.viewportSize() ?? FALLBACK_VIEWPORT
+  const size = jpegSize(shot) ?? {
+    width: viewport.width,
+    height: viewport.height,
+  }
+  return {
+    data: shot.toString("base64"),
+    meta: {
+      deviceWidth: viewport.width,
+      deviceHeight: viewport.height,
+      jpegWidth: size.width,
+      jpegHeight: size.height,
+      pageScaleFactor: 1,
+    },
+  }
+}

--- a/src/core/socket.test.ts
+++ b/src/core/socket.test.ts
@@ -17,6 +17,7 @@ import { fileURLToPath } from "node:url"
 import WebSocket, { WebSocketServer } from "ws"
 
 import type { HumanToAgent, RelayMessage } from "../relay/protocol"
+import type { HandoffMode } from "../types"
 import { connectRelay, type RelayConnection } from "./socket"
 
 const SERVER_PATH = fileURLToPath(
@@ -58,11 +59,11 @@ async function until(
 }
 
 /** The real relay, on an OS-assigned port read back out of its startup log. */
-function startRelayProcess(): Promise<{
+function startRelayProcess(mode: HandoffMode = "takeover"): Promise<{
   port: number
   process: ChildProcessByStdio<null, Readable, Readable>
 }> {
-  const child = spawn(process.execPath, [SERVER_PATH, "0"], {
+  const child = spawn(process.execPath, [SERVER_PATH, "0", "", mode], {
     stdio: ["ignore", "pipe", "pipe"],
   })
   cleanups.push(() => {
@@ -343,3 +344,89 @@ test("close() ends the handoff and stops reconnecting", async () => {
   await connection.send({ type: "state", reason: "too late" })
   expect(fake.received.length).toBe(sent)
 })
+
+/**
+ * One of every message the human can send, exhaustive by construction: the
+ * mapped type below is keyed by `HumanToAgent["type"]`, so adding a member to
+ * the protocol is a compile error here until it is listed.
+ */
+const SAMPLES = {
+  tap: { type: "tap", fx: 412, fy: 233 },
+  char: { type: "char", ch: "7" },
+  key: { type: "key", key: "Enter" },
+  clear: { type: "clear" },
+  scroll: { type: "scroll", fdy: 40 },
+  handback: { type: "handback" },
+  abort: { type: "abort" },
+  approve: { type: "approve" },
+  deny: { type: "deny" },
+} satisfies { [K in HumanToAgent["type"]]: Extract<HumanToAgent, { type: K }> }
+
+/** Which mode's relay routes which of them (`HUMAN_MESSAGES` in guest/server.js). */
+const ROUTED_BY = {
+  takeover: ["tap", "char", "key", "clear", "scroll", "handback", "abort"],
+  approval: ["approve", "deny"],
+} satisfies Record<HandoffMode, HumanToAgent["type"][]>
+
+/** The answers that end a handoff. The relay accepts the first one and no more. */
+const TERMINAL = new Set<string>(["handback", "abort", "approve", "deny"])
+
+/** Send a batch through one relay, and report what came out the other end. */
+async function deliverBatch(
+  mode: HandoffMode,
+  types: HumanToAgent["type"][],
+): Promise<HumanToAgent["type"][]> {
+  const relay = await startRelayProcess(mode)
+  const received: HumanToAgent[] = []
+  const connection = track(
+    connectRelay({
+      url: `ws://127.0.0.1:${relay.port}/ws?role=agent`,
+      onMessage: (message) => received.push(message),
+    }),
+  )
+  await until("the agent socket to open", () => connection.isOpen())
+  const human = await rawPeer(relay.port, "human")
+
+  for (const type of types) human.socket.send(JSON.stringify(SAMPLES[type]))
+  await until(
+    `all ${types.length} ${mode} messages to arrive`,
+    () => received.length === types.length,
+  )
+  return received.map((message) => message.type)
+}
+
+/**
+ * Send everything this mode routes, and report what came out the other end.
+ * One relay per terminal answer, because the first answer ends the handoff and
+ * the relay then correctly refuses the rest.
+ */
+async function deliverThroughRelay(
+  mode: HandoffMode,
+): Promise<HumanToAgent["type"][]> {
+  const routed: HumanToAgent["type"][] = [...ROUTED_BY[mode]]
+  const ordinary = routed.filter((type) => !TERMINAL.has(type))
+  const seen = ordinary.length > 0 ? await deliverBatch(mode, ordinary) : []
+  for (const type of routed.filter((each) => TERMINAL.has(each))) {
+    seen.push(...(await deliverBatch(mode, [type])))
+  }
+  return seen
+}
+
+test("every human message the protocol defines reaches the agent", async () => {
+  // The human's vocabulary is written down three times: the protocol union,
+  // the relay's per-mode HUMAN_MESSAGES, and the switch in socket.ts. They
+  // drifted once — `clear` was in the first two and missing from the third, so
+  // the phone's Clear key left the socket and died in the agent's own router,
+  // silently. This is the test that turns that drift into a red build.
+  const takeover = await deliverThroughRelay("takeover")
+  const approval = await deliverThroughRelay("approval")
+
+  expect(takeover).toEqual(ROUTED_BY.takeover)
+  expect(approval).toEqual(ROUTED_BY.approval)
+
+  // And no message in the protocol is routed by neither mode.
+  const routed = new Set<string>([...ROUTED_BY.takeover, ...ROUTED_BY.approval])
+  for (const type of Object.keys(SAMPLES)) {
+    expect(routed.has(type)).toBe(true)
+  }
+}, 15000)

--- a/src/core/socket.ts
+++ b/src/core/socket.ts
@@ -142,6 +142,7 @@ export function connectRelay(options: RelayConnectionOptions): RelayConnection {
       case "tap":
       case "char":
       case "key":
+      case "clear":
       case "scroll":
       case "handback":
       case "abort":

--- a/src/core/socket.ts
+++ b/src/core/socket.ts
@@ -145,6 +145,11 @@ export function connectRelay(options: RelayConnectionOptions): RelayConnection {
       case "scroll":
       case "handback":
       case "abort":
+      case "approve":
+      case "deny":
+        // Which of these the mode actually acts on is `runHandoff`'s decision,
+        // and the relay's before that. This switch only says what may be a
+        // human message at all.
         if (!shuttingDown) options.onMessage(message)
         return
       default:

--- a/src/events.ts
+++ b/src/events.ts
@@ -34,7 +34,11 @@ export interface HandoffEvent {
   relayColdStartMs: number
   /** Time from handoff start until the first frame was sent, in ms. */
   firstFrameMs?: number
-  /** Frames handed to the relay over the handoff. Always 1 in approval mode. */
+  /**
+   * Frames handed to the relay over the handoff. In approval mode this is the
+   * one screenshot, sent once per connection because a reconnecting agent has
+   * to put it back on the wire: `1 + reconnects`.
+   */
   framesSent: number
   /** Sum of the base64 frame-payload lengths sent, in bytes. */
   bytesSent: number

--- a/src/events.ts
+++ b/src/events.ts
@@ -11,13 +11,19 @@
  * It never carries a secret: no `pt_token`, no API key, no frame bytes, no
  * characters the human typed.
  */
-import type { HandoffOutcome } from "./types"
+import type { HandoffMode, HandoffOutcome } from "./types"
 
 export interface HandoffEvent {
   /** Correlates the event with the relay's own logs (the preview subdomain). */
   handoffId: string
   /** How the handoff ended. */
   outcome: HandoffOutcome
+  /**
+   * What the human was asked for: `takeover` (drive the browser) or
+   * `approval` (answer yes or no about one screenshot). Which outcomes,
+   * frame counts and input counts are possible follows from it.
+   */
+  mode: HandoffMode
   /** The `reason` the agent gave, verbatim — this is shown to the human too. */
   reason: string
   /** The wait budget that was in force, in ms. */
@@ -28,11 +34,14 @@ export interface HandoffEvent {
   relayColdStartMs: number
   /** Time from handoff start until the first frame was sent, in ms. */
   firstFrameMs?: number
-  /** Frames handed to the relay over the handoff. */
+  /** Frames handed to the relay over the handoff. Always 1 in approval mode. */
   framesSent: number
   /** Sum of the base64 frame-payload lengths sent, in bytes. */
   bytesSent: number
-  /** Taps, characters, keys and scrolls the human applied to the page. */
+  /**
+   * Taps, characters, keys and scrolls the human applied to the page. Always 0
+   * in approval mode, which injects nothing.
+   */
   inputsApplied: number
   /** Agent-socket reconnects during the handoff (the 60 s idle cut, drops). */
   reconnects: number

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,16 @@
  *   })
  *   if (result.outcome !== "resolved") throw new Error("nobody helped")
  *
+ * Or ask instead of hand over, when the agent is not stuck but is about to do
+ * something it may not decide alone:
+ *
+ *   const ok = await raiseHand(page, {
+ *     mode: "approval",
+ *     reason: "The agent may not move money without a human",
+ *     action: "Submit $12,430 vendor payment to Acme GmbH",
+ *   })
+ *   if (ok.outcome !== "approved") return
+ *
  * Needs `SOLARI_API_KEY` in the environment: the handoff page is served from a
  * Solari sandbox that handraise creates and destroys around the call.
  */
@@ -30,10 +40,14 @@ export {
   needHumanToolSpec,
 } from "./tool"
 export type {
+  ApprovalOptions,
+  HandoffMode,
+  HandoffOptions,
   HandoffOutcome,
   HandoffResult,
   RaiseHand,
   RaiseHandOptions,
   StorageState,
+  TakeoverOptions,
 } from "./types"
 export type { WebhookPayload } from "./webhook"

--- a/src/relay/deploy.ts
+++ b/src/relay/deploy.ts
@@ -16,6 +16,7 @@ import {
 } from "@solarisdk/sdk"
 
 import { type Logger, quietLogger } from "../logger"
+import type { HandoffMode } from "../types"
 import { GUEST_SERVER_JS } from "./guest-source"
 import { RELAY_PORT } from "./protocol"
 
@@ -50,6 +51,12 @@ const KILL_ATTEMPTS = 4
 
 export interface StartRelayOptions {
   apiKey: string
+  /**
+   * What the relay lets the human do: drive the browser (`takeover`, the
+   * default) or answer one question (`approval`). It is baked into the guest
+   * process at boot, so the human's socket cannot talk it into the other set.
+   */
+  mode?: HandoffMode
   /** Sandbox idle window in ms. Default: 20 minutes. */
   timeoutMs?: number
   /** Gateway base URL. Defaults to the SDK's `https://api.getsolari.com`. */
@@ -172,6 +179,9 @@ export async function startRelay(
   // to `agentWsUrl` alone, never to the human's link, so possession of the
   // handoff URL cannot be used to read the human's keystrokes.
   const agentKey = randomUUID()
+  // Fixed at boot, never taken from a message: the relay's whole job in
+  // approval mode is to refuse what the takeover UI would have sent.
+  const mode: HandoffMode = options.mode ?? "takeover"
   const sandbox = await createSandbox(client, timeoutMs)
 
   let killed = false
@@ -211,7 +221,7 @@ export async function startRelay(
     await sandbox.commands.run("sh", {
       args: [
         "-c",
-        `nohup node ${GUEST_PATH} ${RELAY_PORT} ${agentKey} >${GUEST_LOG} 2>&1 & sleep 0.2; echo started`,
+        `nohup node ${GUEST_PATH} ${RELAY_PORT} ${agentKey} ${mode} >${GUEST_LOG} 2>&1 & sleep 0.2; echo started`,
       ],
     })
 

--- a/src/relay/deploy.ts
+++ b/src/relay/deploy.ts
@@ -181,7 +181,14 @@ export async function startRelay(
   const agentKey = randomUUID()
   // Fixed at boot, never taken from a message: the relay's whole job in
   // approval mode is to refuse what the takeover UI would have sent.
-  const mode: HandoffMode = options.mode ?? "takeover"
+  //
+  // Constructed here rather than passed through, because it is interpolated
+  // into the `sh -c` line below. `raiseHand` already rejects anything that is
+  // not one of these two words, and TypeScript closes it for its own callers,
+  // but this package ships as JavaScript: the value that reaches a shell is
+  // one of two literals written in this file, whatever the caller supplied.
+  const mode: HandoffMode =
+    options.mode === "approval" ? "approval" : "takeover"
   const sandbox = await createSandbox(client, timeoutMs)
 
   let killed = false

--- a/src/relay/guest-source.ts
+++ b/src/relay/guest-source.ts
@@ -99,12 +99,35 @@ let lastFocus = null
 /** The terminal \`ended\` message, once the agent has sent it. */
 let lastEnded = null
 /**
- * A terminal human message (handback/abort) held for an agent that is not
- * connected at the moment — typically mid-reconnect. Delivered to the next
- * role=agent so the handoff resolves instead of falsely timing out with no
+ * A terminal human message (handback/abort/approve/deny) held for an agent that
+ * is not connected at the moment — typically mid-reconnect. Delivered to the
+ * next role=agent so the handoff resolves instead of falsely timing out with no
  * storageState. Symmetric to the lastFrame replay for a late human.
  */
 let pendingForAgent = null
+
+/**
+ * Set by the first terminal human message, and never cleared.
+ *
+ * The handoff link is a bearer URL and may be in two hands at once. Without
+ * this, a second holder could overwrite a queued \`deny\` with an \`approve\`
+ * before the agent reconnected to collect it — the answer the agent acts on
+ * would be the last one sent rather than the first one given. It also stops a
+ * reconnecting agent from refilling the replay buffers this relay has just
+ * scrubbed, because the agent does not yet know it has been answered.
+ */
+let humanEnded = false
+
+/**
+ * Forget everything that shows the remote page. Not the ending, which a late
+ * human still has to be told, and not a human answer still waiting for its
+ * agent.
+ */
+function forgetPage() {
+  lastFrame = null
+  lastState = null
+  lastFocus = null
+}
 
 function encodeFrame(payload, opcode) {
   const body = Buffer.isBuffer(payload) ? payload : Buffer.from(payload)
@@ -219,6 +242,13 @@ function closePeer(peer, reason) {
   if (!peer.open) return
   peer.open = false
   if (peers.get(peer.role) === peer) peers.delete(peer.role)
+  // An agent that is gone may never come back — a timeout during a socket
+  // outage, a killed process, a \`kill()\` that failed — and its last frame is
+  // the logged-in page. \`ended\` is not guaranteed to arrive (the agent gives
+  // up on it after two seconds), so the scrub cannot wait for it. A handoff
+  // that is still running restores this by itself: every agent reconnect
+  // re-sends its state, and in approval mode its screenshot.
+  if (peer.role === "agent") forgetPage()
   // Detach the reader so a replaced client that ignores the close frame can no
   // longer feed route(); a lingering listener is how a peer keeps injecting.
   if (peer.read) peer.socket.removeListener("data", peer.read)
@@ -258,46 +288,54 @@ function messageType(payload) {
 
 /** Keep what a human who joins late has to be shown, and drop what they must not. */
 function rememberFromAgent(type, payload) {
-  if (type === "frame") lastFrame = payload
-  else if (type === "state") lastState = payload
-  else if (type === "focus") lastFocus = payload
-  else if (type === "ended") {
+  if (type === "ended") {
     // Terminal: keep the ending for a late human, drop everything that could
     // show the logged-in page to whoever opens the link next.
     lastEnded = payload
-    lastFrame = null
-    lastState = null
-    lastFocus = null
+    forgetPage()
     pendingForAgent = null
+    return
   }
+  // The agent goes on sending until it learns it has been answered — it
+  // re-sends state, and in approval mode the screenshot, on every reconnect.
+  // Forwarding that is harmless; storing it would put the page back in front
+  // of the next visitor after this relay decided to drop it.
+  if (humanEnded) return
+  if (type === "frame") lastFrame = payload
+  else if (type === "state") lastState = payload
+  else if (type === "focus") lastFocus = payload
 }
 
-/** One line per handoff at most: a hostile client must not be able to fill the log. */
+/** One line per relay at most: a hostile client must not be able to fill the log. */
 let dropLogged = false
+
+function logDrop(type) {
+  if (dropLogged) return
+  dropLogged = true
+  log("human message dropped", {
+    type: String(type).slice(0, 32),
+    mode: MODE,
+    ended: humanEnded,
+  })
+}
 
 /**
  * Whether a human message may be forwarded at all, and the bookkeeping the
- * terminal ones need. This is where the mode is actually enforced: a \`tap\` on
- * an approval relay dies here, not on the phone that never offered it.
+ * terminal ones need. Two rules meet here, and neither is the phone's to
+ * enforce: the mode's vocabulary — a \`tap\` on an approval relay dies here, not
+ * on the page that never offered it — and first answer wins.
  */
 function acceptFromHuman(type, payload) {
-  if (!HUMAN_MESSAGES.has(type)) {
-    if (!dropLogged) {
-      dropLogged = true
-      log("human message dropped", {
-        type: String(type).slice(0, 32),
-        mode: MODE,
-      })
-    }
+  if (humanEnded || !HUMAN_MESSAGES.has(type)) {
+    logDrop(type)
     return false
   }
   if (TERMINAL_HUMAN.has(type)) {
-    // The human is done. Buffer this for an agent that is mid-reconnect, and
-    // stop replaying the last (logged-in) frame to a late human.
+    // The human is done, for good. Buffer this for an agent that is
+    // mid-reconnect, and stop replaying the last (logged-in) frame.
+    humanEnded = true
     pendingForAgent = payload
-    lastFrame = null
-    lastState = null
-    lastFocus = null
+    forgetPage()
   }
   return true
 }
@@ -876,6 +914,13 @@ const PAGE = \`<!doctype html>
     letter-spacing: -0.02em;
     overflow-wrap: anywhere;
   }
+  /* Peers, and deliberately so. The accent marks the action the interface
+     wants, or nothing (docs/design/phone-ui-audit.md): in a takeover that is
+     "Hand back", and in an approval there is no such answer — an interface
+     that recommends one is training the thumb to take the loudest button. So
+     the two answers are drawn identically and the only asymmetry is the
+     gesture. */
+  #deny, #approve { flex: 1 1 0; }
   /* Approval inverts the takeover's risk: here the answer that cannot be taken
      back is yes, so yes is the one that costs a hold. The fill stays
      monochrome — the red in this interface means destructive, and approving
@@ -934,7 +979,7 @@ const PAGE = \`<!doctype html>
       <button id="abort" class="ghost" type="button"><span class="ghost-label">I can't do this</span></button>
     </div>
     <div class="row approval-only">
-      <button id="deny" class="primary" type="button">Deny</button>
+      <button id="deny" class="ghost" type="button"><span class="ghost-label">Deny</span></button>
       <button id="approve" class="ghost" type="button"><span class="ghost-label">Hold to approve</span></button>
     </div>
   </footer>
@@ -1848,7 +1893,9 @@ const PAGE = \`<!doctype html>
     sock.onopen = function () {
       if (mine !== generation) { sock.close(); return }
       retries = 0
-      setStatus(true)
+      // A page that has already ended is not "live" again; this socket exists
+      // only to carry what is still queued.
+      if (!finished) setStatus(true)
       flushOutbox()
       // finish() left this socket open for exactly that flush.
       if (finished) sock.close()
@@ -1858,8 +1905,12 @@ const PAGE = \`<!doctype html>
       // A stale socket (already superseded) must not touch shared state.
       if (mine !== generation) return
       ws = null
-      if (finished) return
-      setStatus(false)
+      // Being finished is not enough to stop: an answer made while this socket
+      // was already CLOSING is sitting in the outbox, and it is the one message
+      // the agent is waiting for. Abandoning it here showed the human
+      // "Approved" and left the agent to time out.
+      if (finished && !stillSending()) return
+      if (!finished) setStatus(false)
       scheduleReconnect()
     }
     sock.onerror = function () { if (mine === generation) sock.close() }

--- a/src/relay/guest-source.ts
+++ b/src/relay/guest-source.ts
@@ -1020,6 +1020,10 @@ const PAGE = \`<!doctype html>
   var retries = 0
   var finished = false
   var reconnectTimer = null
+  // Non-zero only after finish() with something still queued: the wall-clock
+  // time past which the flush gives up. Zero while the handoff is live, which
+  // is what keeps a running handoff reconnecting forever the way it always has.
+  var flushDeadline = 0
   // Every connect() bumps this; a displaced socket's stale callbacks compare
   // against it and bow out, so an old onclose never nulls the live socket.
   var generation = 0
@@ -1135,12 +1139,24 @@ const PAGE = \`<!doctype html>
   }
 
   /**
+   * How long the page keeps trying to deliver a queued answer after the human
+   * has finished. A relay that is actually alive reconnects in seconds — this
+   * covers several backoff cycles of that. Past it the agent has timed out and
+   * killed the sandbox, so the host is gone and retrying it every 8s forever
+   * only spins a dead tab; the backoff caps the wait between attempts, not
+   * their number, so this is what caps their number.
+   */
+  var FLUSH_DEADLINE_MS = 30000
+
+  /**
    * A handback or an abort made while the socket was down still has to arrive:
    * the agent is waiting on exactly that message and would otherwise burn its
-   * whole five-minute timeout on a human who already answered.
+   * whole five-minute timeout on a human who already answered. But only until
+   * the flush deadline: after finish(), a dead host is not worth retrying past
+   * the point a live one would have answered.
    */
   function stillSending() {
-    return outbox.length > 0
+    return outbox.length > 0 && (flushDeadline === 0 || Date.now() < flushDeadline)
   }
 
   function setStatus(live) {
@@ -1744,6 +1760,10 @@ const PAGE = \`<!doctype html>
     setClearEnabled()
     applyKind("text")
     kbd.blur()
+    // A queued answer now has a deadline: keep reconnecting to flush it, but
+    // not forever against a host that may already be gone. Set before the
+    // stillSending() check below so both read the same state.
+    if (outbox.length > 0) flushDeadline = Date.now() + FLUSH_DEADLINE_MS
     // Only close once there is nothing left to deliver. A give-up made during a
     // reconnect has to reach the agent, or it waits out its whole timeout for a
     // human who already answered.

--- a/src/relay/guest-source.ts
+++ b/src/relay/guest-source.ts
@@ -21,10 +21,13 @@ export const GUEST_SERVER_JS = `/**
  *   - The preview proxy kills a silent WebSocket after exactly 60s (close 1006),
  *     hence the 20s server-side ping below and the client's own 20s heartbeat.
  *
- * Routing contract (src/relay/protocol.ts): this is a dumb router. Everything
- * an agent sends goes to the human and vice versa, byte for byte. The only two
- * exceptions are answering \`{"type":"ping"}\` with \`{"type":"pong"}\` and keeping
- * the last \`frame\`/\`state\` so a human who joins late sees something instantly.
+ * Routing contract (src/relay/protocol.ts): everything an agent sends goes to
+ * the human and vice versa, byte for byte. The exceptions are answering
+ * \`{"type":"ping"}\` with \`{"type":"pong"}\`, keeping the last \`frame\`/\`state\` so
+ * a human who joins late sees something instantly, and the mode: this process
+ * is started as a takeover relay or an approval relay and routes only the human
+ * messages that mode has. A hidden button is not a restriction — the human's
+ * socket is reachable from any HTTP client.
  */
 import { createHash } from "node:crypto"
 import { createServer } from "node:http"
@@ -39,6 +42,29 @@ const PORT = Number(process.argv[2] || process.env.HANDRAISE_RELAY_PORT || 3000)
  * local tests; the real deploy always sets one.
  */
 const AGENT_KEY = process.argv[3] || process.env.HANDRAISE_AGENT_KEY || ""
+
+/**
+ * What this handoff asks of the human: \`takeover\` (drive the page) or
+ * \`approval\` (answer one question about one screenshot). It arrives as argv
+ * and never as a message, so no client can talk the relay into the other set.
+ */
+const MODE =
+  (process.argv[4] || process.env.HANDRAISE_MODE) === "approval"
+    ? "approval"
+    : "takeover"
+
+/** The human messages this relay forwards. Everything else from that side is dropped. */
+const HUMAN_MESSAGES = new Set(
+  MODE === "approval"
+    ? ["approve", "deny"]
+    : ["tap", "char", "key", "clear", "scroll", "handback", "abort"],
+)
+
+/**
+ * The human messages that end a handoff, in either mode. They are held for an
+ * agent that is not connected at the moment, and they stop the frame replay.
+ */
+const TERMINAL_HUMAN = new Set(["handback", "abort", "approve", "deny"])
 
 /** Must equal HEARTBEAT_INTERVAL_MS in src/relay/protocol.ts (asserted in relay.test.ts). */
 const HEARTBEAT_INTERVAL_MS = 20000
@@ -230,40 +256,71 @@ function messageType(payload) {
   return type === undefined ? null : type
 }
 
+/** Keep what a human who joins late has to be shown, and drop what they must not. */
+function rememberFromAgent(type, payload) {
+  if (type === "frame") lastFrame = payload
+  else if (type === "state") lastState = payload
+  else if (type === "focus") lastFocus = payload
+  else if (type === "ended") {
+    // Terminal: keep the ending for a late human, drop everything that could
+    // show the logged-in page to whoever opens the link next.
+    lastEnded = payload
+    lastFrame = null
+    lastState = null
+    lastFocus = null
+    pendingForAgent = null
+  }
+}
+
+/** One line per handoff at most: a hostile client must not be able to fill the log. */
+let dropLogged = false
+
+/**
+ * Whether a human message may be forwarded at all, and the bookkeeping the
+ * terminal ones need. This is where the mode is actually enforced: a \`tap\` on
+ * an approval relay dies here, not on the phone that never offered it.
+ */
+function acceptFromHuman(type, payload) {
+  if (!HUMAN_MESSAGES.has(type)) {
+    if (!dropLogged) {
+      dropLogged = true
+      log("human message dropped", {
+        type: String(type).slice(0, 32),
+        mode: MODE,
+      })
+    }
+    return false
+  }
+  if (TERMINAL_HUMAN.has(type)) {
+    // The human is done. Buffer this for an agent that is mid-reconnect, and
+    // stop replaying the last (logged-in) frame to a late human.
+    pendingForAgent = payload
+    lastFrame = null
+    lastState = null
+    lastFocus = null
+  }
+  return true
+}
+
 function route(peer, payload, opcode) {
   // A peer that has been closed or replaced (its role now points at a newer
   // socket) must not route anything, even if its reader fires one more time.
   if (!peer.open || peers.get(peer.role) !== peer) return
   const other = peers.get(peer.role === "agent" ? "human" : "agent")
-  let type = null
-  if (opcode === OP_TEXT) {
-    type = messageType(payload)
-    if (type === "ping") {
-      sendText(peer, PONG)
-      return
-    }
-    if (peer.role === "agent") {
-      if (type === "frame") lastFrame = payload
-      else if (type === "state") lastState = payload
-      else if (type === "focus") lastFocus = payload
-      else if (type === "ended") {
-        // Terminal: keep the ending for a late human, drop everything that
-        // could show the logged-in page to whoever opens the link next.
-        lastEnded = payload
-        lastFrame = null
-        lastState = null
-        lastFocus = null
-        pendingForAgent = null
-      }
-    } else if (type === "handback" || type === "abort") {
-      // The human is done. Buffer this for an agent that is mid-reconnect, and
-      // stop replaying the last (logged-in) frame to a late human.
-      pendingForAgent = payload
-      lastFrame = null
-      lastState = null
-      lastFocus = null
-    }
+  if (opcode !== OP_TEXT) {
+    // The human's whole vocabulary is JSON text; binary from that side is not
+    // in it. The agent's frames are text too, but it owns the channel.
+    if (peer.role === "human") return
+    write(other, payload, opcode)
+    return
   }
+  const type = messageType(payload)
+  if (type === "ping") {
+    sendText(peer, PONG)
+    return
+  }
+  if (peer.role === "agent") rememberFromAgent(type, payload)
+  else if (!acceptFromHuman(type, payload)) return
   // Newest frame wins: drop a frame bound for a backpressured receiver rather
   // than queue it in memory. Control and terminal messages are never dropped.
   if (type === "frame" && other?.backpressure) return
@@ -297,7 +354,9 @@ const server = createServer((req, res) => {
       "content-type": "text/html; charset=utf-8",
       "cache-control": "no-store",
     })
-    res.end(PAGE)
+    // MODE is one of two literals, so this substitution can only produce the
+    // two pages this file was written for.
+    res.end(PAGE.replace("__HANDRAISE_MODE__", MODE))
     return
   }
   res.writeHead(404, {
@@ -406,7 +465,7 @@ server.listen(PORT, "0.0.0.0", () => {
   // Report the bound port, not the requested one: port 0 asks the OS to pick a
   // free one, which is how the local test suite avoids fighting for 3000.
   const bound = server.address()
-  log("relay listening", { port: bound?.port ?? PORT })
+  log("relay listening", { port: bound?.port ?? PORT, mode: MODE })
 })
 
 const PAGE = \`<!doctype html>
@@ -801,12 +860,35 @@ const PAGE = \`<!doctype html>
   #overlay[hidden] { display: none; }
   #overlay h1 { margin: 0; font-size: 20px; letter-spacing: -0.02em; }
   #overlay p { margin: 0; color: var(--muted); font-size: 14px; }
+  /* One page, two jobs. The relay bakes the mode into the body, and the
+     controls belonging to the other job are gone rather than disabled: the
+     relay refuses to route what they would have sent anyway. */
+  body[data-mode="approval"] .takeover-only,
+  body[data-mode="takeover"] .approval-only { display: none; }
+  /* The sentence being decided. Larger than the reason in the header, because
+     the reason says why someone was asked and this is what they answer. */
+  .ask { display: flex; flex-direction: column; gap: 3px; margin: 2px 0 14px; }
+  .ask-label { font-size: 11px; letter-spacing: 0.02em; color: var(--muted); }
+  #action {
+    font-size: 20px;
+    font-weight: 600;
+    line-height: 1.25;
+    letter-spacing: -0.02em;
+    overflow-wrap: anywhere;
+  }
+  /* Approval inverts the takeover's risk: here the answer that cannot be taken
+     back is yes, so yes is the one that costs a hold. The fill stays
+     monochrome — the red in this interface means destructive, and approving
+     something the human just chose is not that. */
+  #approve::before { background: oklch(0.985 0 0 / 0.16); }
+  #approve[data-holding] { border-color: var(--field); }
   @media (prefers-reduced-motion: reduce) {
     button { transition: none; }
     /* Keep the safety, drop the motion: the hold still takes its 700ms, it
        just does not animate getting there. */
     .ghost::before { display: none; }
     .ghost[data-holding] { background: oklch(0.65 0.2 25 / 0.14); }
+    #approve[data-holding] { background: oklch(0.985 0 0 / 0.12); }
     #overlay { transition: opacity 150ms linear; }
     @starting-style {
       #overlay { opacity: 0; transform: none; }
@@ -814,11 +896,11 @@ const PAGE = \`<!doctype html>
   }
 </style>
 </head>
-<body>
+<body data-mode="__HANDRAISE_MODE__">
   <header>
     <span id="dot" class="dot"></span>
     <div class="head-copy">
-      <span class="eyebrow"><span class="mark">handraise</span> · an agent asked for your help</span>
+      <span class="eyebrow"><span class="mark">handraise</span> · <span id="eyebrow-note">an agent asked for your help</span></span>
       <span id="reason">Connecting to the browser…</span>
     </div>
   </header>
@@ -832,7 +914,7 @@ const PAGE = \`<!doctype html>
     <p id="placeholder">Waiting for the first frame…</p>
   </main>
   <footer>
-    <div class="bar">
+    <div class="bar takeover-only">
       <input id="kbd" type="text" autocomplete="off" autocapitalize="off" autocorrect="off"
         spellcheck="false" enterkeyhint="enter" placeholder="Type here">
       <div class="keys">
@@ -842,10 +924,18 @@ const PAGE = \`<!doctype html>
         <button id="key-clear" class="key" type="button" aria-label="Clear the field" disabled>Clear</button>
       </div>
     </div>
+    <p class="ask approval-only">
+      <span class="ask-label">The agent is asking to</span>
+      <span id="action"></span>
+    </p>
     <p class="hint" id="hint">Typing goes straight to the browser</p>
-    <div class="row">
+    <div class="row takeover-only">
       <button id="handback" class="primary" type="button">&#9995; Hand back</button>
       <button id="abort" class="ghost" type="button"><span class="ghost-label">I can't do this</span></button>
+    </div>
+    <div class="row approval-only">
+      <button id="deny" class="primary" type="button">Deny</button>
+      <button id="approve" class="ghost" type="button"><span class="ghost-label">Hold to approve</span></button>
     </div>
   </footer>
   <div id="overlay" hidden>
@@ -868,6 +958,18 @@ const PAGE = \`<!doctype html>
   var overlay = document.getElementById("overlay")
   var overlayTitle = document.getElementById("overlay-title")
   var overlayNote = document.getElementById("overlay-note")
+  var actionEl = document.getElementById("action")
+
+  /**
+   * Takeover or approval, decided by the relay that served this page. In
+   * approval mode the human is answering a question about one screenshot, not
+   * driving anything: the input row and the key bar are not on the page, and
+   * the two messages below are the only ones this side can produce.
+   */
+  var APPROVAL = document.body.dataset.mode === "approval"
+  var SENDABLE = APPROVAL
+    ? { approve: 1, deny: 1, ping: 1 }
+    : { tap: 1, char: 1, key: 1, clear: 1, scroll: 1, handback: 1, abort: 1, ping: 1 }
 
   var ws = null
   var retries = 0
@@ -887,10 +989,14 @@ const PAGE = \`<!doctype html>
   // needed to place the ring, and they arrive in separate messages.
   var meta = null
   var focus = null
-  var HINT_DEFAULT = "Typing goes straight to the browser"
+  var HINT_DEFAULT = APPROVAL
+    ? "Approve needs a hold. Deny is one tap."
+    : "Typing goes straight to the browser"
   /** Long enough that a stray thumb cannot reach it, short enough to not annoy. */
   var HOLD_MS = 700
-  var HOLD_HINT = "Hold the button to stop the agent"
+  var HOLD_HINT = APPROVAL
+    ? "Hold the button to approve"
+    : "Hold the button to stop the agent"
   var QUEUE_HINT = "Reconnecting — your input is queued"
   var QUEUE_FULL_HINT = "Reconnecting — queue full, the oldest input was dropped"
   var hintTimer = null
@@ -933,6 +1039,9 @@ const PAGE = \`<!doctype html>
   var dropped = 0
 
   function send(message) {
+    // The mode's vocabulary, enforced here as well as at the relay: a control
+    // that is not on this page cannot have its message leave it either.
+    if (!SENDABLE[message.type]) return
     if (ws && ws.readyState === 1) {
       ws.send(JSON.stringify(message))
       return
@@ -1343,9 +1452,28 @@ const PAGE = \`<!doctype html>
     )
   }
 
-  function dragScroll(e) {
+  /**
+   * One finger on an approval pans the screenshot. There is no remote page to
+   * scroll — the frame is a still — and a magnified still you cannot move is
+   * a picture of the middle of the page.
+   */
+  function dragPan(e) {
+    var dx = e.clientX - press.lastX
+    var dy = e.clientY - press.lastY
+    press.lastX = e.clientX
+    press.lastY = e.clientY
+    setView(view.scale, view.tx + dx, view.ty + dy, false)
+  }
+
+  /** One finger: a scroll of the remote page, or a pan of the screenshot. */
+  function dragMove(e) {
     press.travel = Math.max(press.travel, Math.hypot(e.clientX - press.x, e.clientY - press.y))
-    if (press.travel < TAP_SLOP_PX || !box.h) return
+    if (press.travel < TAP_SLOP_PX) return
+    if (APPROVAL) {
+      dragPan(e)
+      return
+    }
+    if (!box.h) return
     var now = Date.now()
     if (now - press.sentAt < 60) return
     var stepped = e.clientY - press.lastY
@@ -1369,7 +1497,7 @@ const PAGE = \`<!doctype html>
       beginPinch()
       return
     }
-    press = { x: e.clientX, y: e.clientY, lastY: e.clientY, travel: 0, sentAt: 0 }
+    press = { x: e.clientX, y: e.clientY, lastX: e.clientX, lastY: e.clientY, travel: 0, sentAt: 0 }
   })
   canvas.addEventListener("pointermove", function (e) {
     var point = pointers.get(e.pointerId)
@@ -1381,7 +1509,7 @@ const PAGE = \`<!doctype html>
       updatePinch()
       return
     }
-    if (press) dragScroll(e)
+    if (press) dragMove(e)
   })
   /** Acknowledge the tap where the finger landed, inside the same frame. */
   function markTap(clientX, clientY) {
@@ -1446,6 +1574,9 @@ const PAGE = \`<!doctype html>
       return
     }
     lastTap = { at: now, x: e.clientX, y: e.clientY }
+    // A single tap on an approval does nothing, and says so by doing nothing:
+    // an acknowledgement ripple would promise the remote page had seen it.
+    if (APPROVAL) return
     var point = toFrame(e.clientX, e.clientY)
     if (!point) return
     send({ type: "tap", fx: point.x, fy: point.y })
@@ -1574,75 +1705,96 @@ const PAGE = \`<!doctype html>
     if (ws && !stillSending()) ws.close()
   }
 
-  // The expected ending, and the only one whose worst case is recoverable in
-  // spirit: the agent looks, fails and asks again. Confirming the happy path is
-  // the classic mistake, so this stays a single tap.
-  document.getElementById("handback").addEventListener("click", function () {
-    send({ type: "handback" })
-    finish(ENDINGS.resolved[0], ENDINGS.resolved[1])
-  })
-
-  /**
-   * Giving up ends the handoff for good and there is nothing to undo — the
-   * message leaves the socket and the agent settles on it immediately. So the
-   * gesture costs more than a tap instead of a confirm dialog costing a screen.
-   *
-   * Pointer events only: they cover mouse, touch and pen with one stream, so
-   * the hold cannot start twice from one finger.
-   */
-  var abortButton = document.getElementById("abort")
-  var holdTimer = null
-  var holdFired = false
-
   function flashHint(text) {
     hint.textContent = text
     if (hintTimer) clearTimeout(hintTimer)
     hintTimer = setTimeout(function () { hintTimer = null; setHint() }, 2200)
   }
 
-  function startHold() {
-    if (holdTimer || finished) return
-    abortButton.dataset.holding = ""
-    holdTimer = setTimeout(function () {
-      holdTimer = null
-      holdFired = true
-      delete abortButton.dataset.holding
-      if (navigator.vibrate) navigator.vibrate(20)
-      send({ type: "abort" })
-      finish("Thanks for looking", "The agent knows it can't be done here and will stop. You can close this tab.")
-    }, HOLD_MS)
-  }
+  /**
+   * Press-and-hold, for the one answer in each mode that cannot be taken back:
+   * giving up in a takeover, approving in an approval. The message leaves the
+   * socket and the agent settles on it immediately, so the gesture costs more
+   * than a tap instead of a confirm dialog costing a screen.
+   *
+   * Pointer events only: they cover mouse, touch and pen with one stream, so
+   * the hold cannot start twice from one finger.
+   */
+  function holdButton(button, run) {
+    var holdTimer = null
+    var holdFired = false
 
-  function cancelHold() {
-    if (holdTimer) { clearTimeout(holdTimer); holdTimer = null }
-    delete abortButton.dataset.holding
-  }
+    function startHold() {
+      if (holdTimer || finished) return
+      button.dataset.holding = ""
+      holdTimer = setTimeout(function () {
+        holdTimer = null
+        holdFired = true
+        delete button.dataset.holding
+        if (navigator.vibrate) navigator.vibrate(20)
+        run()
+      }, HOLD_MS)
+    }
 
-  abortButton.addEventListener("pointerdown", startHold)
-  abortButton.addEventListener("pointerup", cancelHold)
-  abortButton.addEventListener("pointercancel", cancelHold)
-  abortButton.addEventListener("pointerleave", cancelHold)
-  // A keyboard has no press-and-hold of its own, so held Space or Enter is the
-  // same contract. Without this the button is unreachable without a pointer.
-  abortButton.addEventListener("keydown", function (e) {
-    if (e.key !== " " && e.key !== "Enter") return
-    e.preventDefault()
-    if (!e.repeat) startHold()
-  })
-  abortButton.addEventListener("keyup", cancelHold)
-  // A release always fires a click. After a completed hold that click is the
-  // same gesture arriving twice; before 700ms it is a tap that did nothing, and
-  // a tap that does nothing has to say why or the human thinks it is broken.
-  abortButton.addEventListener("click", function () {
-    if (holdFired) { holdFired = false; return }
-    flashHint(HOLD_HINT)
-  })
+    function cancelHold() {
+      if (holdTimer) { clearTimeout(holdTimer); holdTimer = null }
+      delete button.dataset.holding
+    }
+
+    button.addEventListener("pointerdown", startHold)
+    button.addEventListener("pointerup", cancelHold)
+    button.addEventListener("pointercancel", cancelHold)
+    button.addEventListener("pointerleave", cancelHold)
+    // A keyboard has no press-and-hold of its own, so held Space or Enter is
+    // the same contract. Without this the button needs a pointer to reach.
+    button.addEventListener("keydown", function (e) {
+      if (e.key !== " " && e.key !== "Enter") return
+      e.preventDefault()
+      if (!e.repeat) startHold()
+    })
+    button.addEventListener("keyup", cancelHold)
+    // A release always fires a click. After a completed hold that click is the
+    // same gesture arriving twice; before 700ms it is a tap that did nothing,
+    // and a tap that does nothing has to say why or it reads as broken.
+    button.addEventListener("click", function () {
+      if (holdFired) { holdFired = false; return }
+      flashHint(HOLD_HINT)
+    })
+  }
 
   var ENDINGS = {
     resolved: ["Thanks — that unblocked it", "The agent is driving again. You can close this tab."],
     aborted: ["Handoff ended", "You couldn't solve it here. Nothing more to do — you can close this tab."],
+    approved: ["Approved", "The agent has your approval and is continuing. You can close this tab."],
+    denied: ["Denied", "The agent has been told not to do it. You can close this tab."],
     timeout: ["Too late", "The agent gave up waiting. Nothing you can do here now."],
     disconnected: ["Connection ended", "The remote browser closed. The agent has been told — this wasn't anything you did."]
+  }
+
+  if (APPROVAL) {
+    // Deny is a single tap because it is the answer that keeps the world as it
+    // is; approve is the hold, because it is the one that cannot be undone.
+    // That is the takeover's rule with the sides swapped, for the same reason.
+    document.getElementById("deny").addEventListener("click", function () {
+      send({ type: "deny" })
+      finish(ENDINGS.denied[0], ENDINGS.denied[1])
+    })
+    holdButton(document.getElementById("approve"), function () {
+      send({ type: "approve" })
+      finish(ENDINGS.approved[0], ENDINGS.approved[1])
+    })
+  } else {
+    // The expected ending, and the only one whose worst case is recoverable in
+    // spirit: the agent looks, fails and asks again. Confirming the happy path
+    // is the classic mistake, so this stays a single tap.
+    document.getElementById("handback").addEventListener("click", function () {
+      send({ type: "handback" })
+      finish(ENDINGS.resolved[0], ENDINGS.resolved[1])
+    })
+    holdButton(document.getElementById("abort"), function () {
+      send({ type: "abort" })
+      finish("Thanks for looking", "The agent knows it can't be done here and will stop. You can close this tab.")
+    })
   }
 
   function handle(raw) {
@@ -1650,7 +1802,12 @@ const PAGE = \`<!doctype html>
     try { message = JSON.parse(raw) } catch (err) { return }
     if (!message) return
     if (message.type === "frame") showFrame(message.data, message.meta)
-    else if (message.type === "state") reason.textContent = message.reason
+    else if (message.type === "state") {
+      reason.textContent = message.reason
+      // textContent, never innerHTML: the action is the agent's own sentence,
+      // and it goes on the screen a decision is made from.
+      if (message.action) actionEl.textContent = message.action
+    }
     else if (message.type === "focus") {
       focus = readFocus(message)
       applyKind(focus.rect ? focus.kind : "text")
@@ -1708,6 +1865,13 @@ const PAGE = \`<!doctype html>
     sock.onerror = function () { if (mine === generation) sock.close() }
   }
 
+  if (APPROVAL) {
+    // The page arrives phrased for a takeover, because that is what it is most
+    // of the time. These three lines are the rest of the difference.
+    document.getElementById("eyebrow-note").textContent = "an agent needs your approval"
+    placeholder.textContent = "Waiting for the screenshot…"
+    setHint()
+  }
   applyTransform(false)
   setInterval(function () { send({ type: "ping" }) }, 20000)
   window.addEventListener("resize", render)

--- a/src/relay/guest/server.js
+++ b/src/relay/guest/server.js
@@ -1011,6 +1011,10 @@ const PAGE = `<!doctype html>
   var retries = 0
   var finished = false
   var reconnectTimer = null
+  // Non-zero only after finish() with something still queued: the wall-clock
+  // time past which the flush gives up. Zero while the handoff is live, which
+  // is what keeps a running handoff reconnecting forever the way it always has.
+  var flushDeadline = 0
   // Every connect() bumps this; a displaced socket's stale callbacks compare
   // against it and bow out, so an old onclose never nulls the live socket.
   var generation = 0
@@ -1126,12 +1130,24 @@ const PAGE = `<!doctype html>
   }
 
   /**
+   * How long the page keeps trying to deliver a queued answer after the human
+   * has finished. A relay that is actually alive reconnects in seconds — this
+   * covers several backoff cycles of that. Past it the agent has timed out and
+   * killed the sandbox, so the host is gone and retrying it every 8s forever
+   * only spins a dead tab; the backoff caps the wait between attempts, not
+   * their number, so this is what caps their number.
+   */
+  var FLUSH_DEADLINE_MS = 30000
+
+  /**
    * A handback or an abort made while the socket was down still has to arrive:
    * the agent is waiting on exactly that message and would otherwise burn its
-   * whole five-minute timeout on a human who already answered.
+   * whole five-minute timeout on a human who already answered. But only until
+   * the flush deadline: after finish(), a dead host is not worth retrying past
+   * the point a live one would have answered.
    */
   function stillSending() {
-    return outbox.length > 0
+    return outbox.length > 0 && (flushDeadline === 0 || Date.now() < flushDeadline)
   }
 
   function setStatus(live) {
@@ -1735,6 +1751,10 @@ const PAGE = `<!doctype html>
     setClearEnabled()
     applyKind("text")
     kbd.blur()
+    // A queued answer now has a deadline: keep reconnecting to flush it, but
+    // not forever against a host that may already be gone. Set before the
+    // stillSending() check below so both read the same state.
+    if (outbox.length > 0) flushDeadline = Date.now() + FLUSH_DEADLINE_MS
     // Only close once there is nothing left to deliver. A give-up made during a
     // reconnect has to reach the agent, or it waits out its whole timeout for a
     // human who already answered.

--- a/src/relay/guest/server.js
+++ b/src/relay/guest/server.js
@@ -90,12 +90,35 @@ let lastFocus = null
 /** The terminal `ended` message, once the agent has sent it. */
 let lastEnded = null
 /**
- * A terminal human message (handback/abort) held for an agent that is not
- * connected at the moment — typically mid-reconnect. Delivered to the next
- * role=agent so the handoff resolves instead of falsely timing out with no
+ * A terminal human message (handback/abort/approve/deny) held for an agent that
+ * is not connected at the moment — typically mid-reconnect. Delivered to the
+ * next role=agent so the handoff resolves instead of falsely timing out with no
  * storageState. Symmetric to the lastFrame replay for a late human.
  */
 let pendingForAgent = null
+
+/**
+ * Set by the first terminal human message, and never cleared.
+ *
+ * The handoff link is a bearer URL and may be in two hands at once. Without
+ * this, a second holder could overwrite a queued `deny` with an `approve`
+ * before the agent reconnected to collect it — the answer the agent acts on
+ * would be the last one sent rather than the first one given. It also stops a
+ * reconnecting agent from refilling the replay buffers this relay has just
+ * scrubbed, because the agent does not yet know it has been answered.
+ */
+let humanEnded = false
+
+/**
+ * Forget everything that shows the remote page. Not the ending, which a late
+ * human still has to be told, and not a human answer still waiting for its
+ * agent.
+ */
+function forgetPage() {
+  lastFrame = null
+  lastState = null
+  lastFocus = null
+}
 
 function encodeFrame(payload, opcode) {
   const body = Buffer.isBuffer(payload) ? payload : Buffer.from(payload)
@@ -210,6 +233,13 @@ function closePeer(peer, reason) {
   if (!peer.open) return
   peer.open = false
   if (peers.get(peer.role) === peer) peers.delete(peer.role)
+  // An agent that is gone may never come back — a timeout during a socket
+  // outage, a killed process, a `kill()` that failed — and its last frame is
+  // the logged-in page. `ended` is not guaranteed to arrive (the agent gives
+  // up on it after two seconds), so the scrub cannot wait for it. A handoff
+  // that is still running restores this by itself: every agent reconnect
+  // re-sends its state, and in approval mode its screenshot.
+  if (peer.role === "agent") forgetPage()
   // Detach the reader so a replaced client that ignores the close frame can no
   // longer feed route(); a lingering listener is how a peer keeps injecting.
   if (peer.read) peer.socket.removeListener("data", peer.read)
@@ -249,46 +279,54 @@ function messageType(payload) {
 
 /** Keep what a human who joins late has to be shown, and drop what they must not. */
 function rememberFromAgent(type, payload) {
-  if (type === "frame") lastFrame = payload
-  else if (type === "state") lastState = payload
-  else if (type === "focus") lastFocus = payload
-  else if (type === "ended") {
+  if (type === "ended") {
     // Terminal: keep the ending for a late human, drop everything that could
     // show the logged-in page to whoever opens the link next.
     lastEnded = payload
-    lastFrame = null
-    lastState = null
-    lastFocus = null
+    forgetPage()
     pendingForAgent = null
+    return
   }
+  // The agent goes on sending until it learns it has been answered — it
+  // re-sends state, and in approval mode the screenshot, on every reconnect.
+  // Forwarding that is harmless; storing it would put the page back in front
+  // of the next visitor after this relay decided to drop it.
+  if (humanEnded) return
+  if (type === "frame") lastFrame = payload
+  else if (type === "state") lastState = payload
+  else if (type === "focus") lastFocus = payload
 }
 
-/** One line per handoff at most: a hostile client must not be able to fill the log. */
+/** One line per relay at most: a hostile client must not be able to fill the log. */
 let dropLogged = false
+
+function logDrop(type) {
+  if (dropLogged) return
+  dropLogged = true
+  log("human message dropped", {
+    type: String(type).slice(0, 32),
+    mode: MODE,
+    ended: humanEnded,
+  })
+}
 
 /**
  * Whether a human message may be forwarded at all, and the bookkeeping the
- * terminal ones need. This is where the mode is actually enforced: a `tap` on
- * an approval relay dies here, not on the phone that never offered it.
+ * terminal ones need. Two rules meet here, and neither is the phone's to
+ * enforce: the mode's vocabulary — a `tap` on an approval relay dies here, not
+ * on the page that never offered it — and first answer wins.
  */
 function acceptFromHuman(type, payload) {
-  if (!HUMAN_MESSAGES.has(type)) {
-    if (!dropLogged) {
-      dropLogged = true
-      log("human message dropped", {
-        type: String(type).slice(0, 32),
-        mode: MODE,
-      })
-    }
+  if (humanEnded || !HUMAN_MESSAGES.has(type)) {
+    logDrop(type)
     return false
   }
   if (TERMINAL_HUMAN.has(type)) {
-    // The human is done. Buffer this for an agent that is mid-reconnect, and
-    // stop replaying the last (logged-in) frame to a late human.
+    // The human is done, for good. Buffer this for an agent that is
+    // mid-reconnect, and stop replaying the last (logged-in) frame.
+    humanEnded = true
     pendingForAgent = payload
-    lastFrame = null
-    lastState = null
-    lastFocus = null
+    forgetPage()
   }
   return true
 }
@@ -867,6 +905,13 @@ const PAGE = `<!doctype html>
     letter-spacing: -0.02em;
     overflow-wrap: anywhere;
   }
+  /* Peers, and deliberately so. The accent marks the action the interface
+     wants, or nothing (docs/design/phone-ui-audit.md): in a takeover that is
+     "Hand back", and in an approval there is no such answer — an interface
+     that recommends one is training the thumb to take the loudest button. So
+     the two answers are drawn identically and the only asymmetry is the
+     gesture. */
+  #deny, #approve { flex: 1 1 0; }
   /* Approval inverts the takeover's risk: here the answer that cannot be taken
      back is yes, so yes is the one that costs a hold. The fill stays
      monochrome — the red in this interface means destructive, and approving
@@ -925,7 +970,7 @@ const PAGE = `<!doctype html>
       <button id="abort" class="ghost" type="button"><span class="ghost-label">I can't do this</span></button>
     </div>
     <div class="row approval-only">
-      <button id="deny" class="primary" type="button">Deny</button>
+      <button id="deny" class="ghost" type="button"><span class="ghost-label">Deny</span></button>
       <button id="approve" class="ghost" type="button"><span class="ghost-label">Hold to approve</span></button>
     </div>
   </footer>
@@ -1839,7 +1884,9 @@ const PAGE = `<!doctype html>
     sock.onopen = function () {
       if (mine !== generation) { sock.close(); return }
       retries = 0
-      setStatus(true)
+      // A page that has already ended is not "live" again; this socket exists
+      // only to carry what is still queued.
+      if (!finished) setStatus(true)
       flushOutbox()
       // finish() left this socket open for exactly that flush.
       if (finished) sock.close()
@@ -1849,8 +1896,12 @@ const PAGE = `<!doctype html>
       // A stale socket (already superseded) must not touch shared state.
       if (mine !== generation) return
       ws = null
-      if (finished) return
-      setStatus(false)
+      // Being finished is not enough to stop: an answer made while this socket
+      // was already CLOSING is sitting in the outbox, and it is the one message
+      // the agent is waiting for. Abandoning it here showed the human
+      // "Approved" and left the agent to time out.
+      if (finished && !stillSending()) return
+      if (!finished) setStatus(false)
       scheduleReconnect()
     }
     sock.onerror = function () { if (mine === generation) sock.close() }

--- a/src/relay/guest/server.js
+++ b/src/relay/guest/server.js
@@ -12,10 +12,13 @@
  *   - The preview proxy kills a silent WebSocket after exactly 60s (close 1006),
  *     hence the 20s server-side ping below and the client's own 20s heartbeat.
  *
- * Routing contract (src/relay/protocol.ts): this is a dumb router. Everything
- * an agent sends goes to the human and vice versa, byte for byte. The only two
- * exceptions are answering `{"type":"ping"}` with `{"type":"pong"}` and keeping
- * the last `frame`/`state` so a human who joins late sees something instantly.
+ * Routing contract (src/relay/protocol.ts): everything an agent sends goes to
+ * the human and vice versa, byte for byte. The exceptions are answering
+ * `{"type":"ping"}` with `{"type":"pong"}`, keeping the last `frame`/`state` so
+ * a human who joins late sees something instantly, and the mode: this process
+ * is started as a takeover relay or an approval relay and routes only the human
+ * messages that mode has. A hidden button is not a restriction — the human's
+ * socket is reachable from any HTTP client.
  */
 import { createHash } from "node:crypto"
 import { createServer } from "node:http"
@@ -30,6 +33,29 @@ const PORT = Number(process.argv[2] || process.env.HANDRAISE_RELAY_PORT || 3000)
  * local tests; the real deploy always sets one.
  */
 const AGENT_KEY = process.argv[3] || process.env.HANDRAISE_AGENT_KEY || ""
+
+/**
+ * What this handoff asks of the human: `takeover` (drive the page) or
+ * `approval` (answer one question about one screenshot). It arrives as argv
+ * and never as a message, so no client can talk the relay into the other set.
+ */
+const MODE =
+  (process.argv[4] || process.env.HANDRAISE_MODE) === "approval"
+    ? "approval"
+    : "takeover"
+
+/** The human messages this relay forwards. Everything else from that side is dropped. */
+const HUMAN_MESSAGES = new Set(
+  MODE === "approval"
+    ? ["approve", "deny"]
+    : ["tap", "char", "key", "clear", "scroll", "handback", "abort"],
+)
+
+/**
+ * The human messages that end a handoff, in either mode. They are held for an
+ * agent that is not connected at the moment, and they stop the frame replay.
+ */
+const TERMINAL_HUMAN = new Set(["handback", "abort", "approve", "deny"])
 
 /** Must equal HEARTBEAT_INTERVAL_MS in src/relay/protocol.ts (asserted in relay.test.ts). */
 const HEARTBEAT_INTERVAL_MS = 20000
@@ -221,40 +247,71 @@ function messageType(payload) {
   return type === undefined ? null : type
 }
 
+/** Keep what a human who joins late has to be shown, and drop what they must not. */
+function rememberFromAgent(type, payload) {
+  if (type === "frame") lastFrame = payload
+  else if (type === "state") lastState = payload
+  else if (type === "focus") lastFocus = payload
+  else if (type === "ended") {
+    // Terminal: keep the ending for a late human, drop everything that could
+    // show the logged-in page to whoever opens the link next.
+    lastEnded = payload
+    lastFrame = null
+    lastState = null
+    lastFocus = null
+    pendingForAgent = null
+  }
+}
+
+/** One line per handoff at most: a hostile client must not be able to fill the log. */
+let dropLogged = false
+
+/**
+ * Whether a human message may be forwarded at all, and the bookkeeping the
+ * terminal ones need. This is where the mode is actually enforced: a `tap` on
+ * an approval relay dies here, not on the phone that never offered it.
+ */
+function acceptFromHuman(type, payload) {
+  if (!HUMAN_MESSAGES.has(type)) {
+    if (!dropLogged) {
+      dropLogged = true
+      log("human message dropped", {
+        type: String(type).slice(0, 32),
+        mode: MODE,
+      })
+    }
+    return false
+  }
+  if (TERMINAL_HUMAN.has(type)) {
+    // The human is done. Buffer this for an agent that is mid-reconnect, and
+    // stop replaying the last (logged-in) frame to a late human.
+    pendingForAgent = payload
+    lastFrame = null
+    lastState = null
+    lastFocus = null
+  }
+  return true
+}
+
 function route(peer, payload, opcode) {
   // A peer that has been closed or replaced (its role now points at a newer
   // socket) must not route anything, even if its reader fires one more time.
   if (!peer.open || peers.get(peer.role) !== peer) return
   const other = peers.get(peer.role === "agent" ? "human" : "agent")
-  let type = null
-  if (opcode === OP_TEXT) {
-    type = messageType(payload)
-    if (type === "ping") {
-      sendText(peer, PONG)
-      return
-    }
-    if (peer.role === "agent") {
-      if (type === "frame") lastFrame = payload
-      else if (type === "state") lastState = payload
-      else if (type === "focus") lastFocus = payload
-      else if (type === "ended") {
-        // Terminal: keep the ending for a late human, drop everything that
-        // could show the logged-in page to whoever opens the link next.
-        lastEnded = payload
-        lastFrame = null
-        lastState = null
-        lastFocus = null
-        pendingForAgent = null
-      }
-    } else if (type === "handback" || type === "abort") {
-      // The human is done. Buffer this for an agent that is mid-reconnect, and
-      // stop replaying the last (logged-in) frame to a late human.
-      pendingForAgent = payload
-      lastFrame = null
-      lastState = null
-      lastFocus = null
-    }
+  if (opcode !== OP_TEXT) {
+    // The human's whole vocabulary is JSON text; binary from that side is not
+    // in it. The agent's frames are text too, but it owns the channel.
+    if (peer.role === "human") return
+    write(other, payload, opcode)
+    return
   }
+  const type = messageType(payload)
+  if (type === "ping") {
+    sendText(peer, PONG)
+    return
+  }
+  if (peer.role === "agent") rememberFromAgent(type, payload)
+  else if (!acceptFromHuman(type, payload)) return
   // Newest frame wins: drop a frame bound for a backpressured receiver rather
   // than queue it in memory. Control and terminal messages are never dropped.
   if (type === "frame" && other?.backpressure) return
@@ -288,7 +345,9 @@ const server = createServer((req, res) => {
       "content-type": "text/html; charset=utf-8",
       "cache-control": "no-store",
     })
-    res.end(PAGE)
+    // MODE is one of two literals, so this substitution can only produce the
+    // two pages this file was written for.
+    res.end(PAGE.replace("__HANDRAISE_MODE__", MODE))
     return
   }
   res.writeHead(404, {
@@ -397,7 +456,7 @@ server.listen(PORT, "0.0.0.0", () => {
   // Report the bound port, not the requested one: port 0 asks the OS to pick a
   // free one, which is how the local test suite avoids fighting for 3000.
   const bound = server.address()
-  log("relay listening", { port: bound?.port ?? PORT })
+  log("relay listening", { port: bound?.port ?? PORT, mode: MODE })
 })
 
 const PAGE = `<!doctype html>
@@ -792,12 +851,35 @@ const PAGE = `<!doctype html>
   #overlay[hidden] { display: none; }
   #overlay h1 { margin: 0; font-size: 20px; letter-spacing: -0.02em; }
   #overlay p { margin: 0; color: var(--muted); font-size: 14px; }
+  /* One page, two jobs. The relay bakes the mode into the body, and the
+     controls belonging to the other job are gone rather than disabled: the
+     relay refuses to route what they would have sent anyway. */
+  body[data-mode="approval"] .takeover-only,
+  body[data-mode="takeover"] .approval-only { display: none; }
+  /* The sentence being decided. Larger than the reason in the header, because
+     the reason says why someone was asked and this is what they answer. */
+  .ask { display: flex; flex-direction: column; gap: 3px; margin: 2px 0 14px; }
+  .ask-label { font-size: 11px; letter-spacing: 0.02em; color: var(--muted); }
+  #action {
+    font-size: 20px;
+    font-weight: 600;
+    line-height: 1.25;
+    letter-spacing: -0.02em;
+    overflow-wrap: anywhere;
+  }
+  /* Approval inverts the takeover's risk: here the answer that cannot be taken
+     back is yes, so yes is the one that costs a hold. The fill stays
+     monochrome — the red in this interface means destructive, and approving
+     something the human just chose is not that. */
+  #approve::before { background: oklch(0.985 0 0 / 0.16); }
+  #approve[data-holding] { border-color: var(--field); }
   @media (prefers-reduced-motion: reduce) {
     button { transition: none; }
     /* Keep the safety, drop the motion: the hold still takes its 700ms, it
        just does not animate getting there. */
     .ghost::before { display: none; }
     .ghost[data-holding] { background: oklch(0.65 0.2 25 / 0.14); }
+    #approve[data-holding] { background: oklch(0.985 0 0 / 0.12); }
     #overlay { transition: opacity 150ms linear; }
     @starting-style {
       #overlay { opacity: 0; transform: none; }
@@ -805,11 +887,11 @@ const PAGE = `<!doctype html>
   }
 </style>
 </head>
-<body>
+<body data-mode="__HANDRAISE_MODE__">
   <header>
     <span id="dot" class="dot"></span>
     <div class="head-copy">
-      <span class="eyebrow"><span class="mark">handraise</span> · an agent asked for your help</span>
+      <span class="eyebrow"><span class="mark">handraise</span> · <span id="eyebrow-note">an agent asked for your help</span></span>
       <span id="reason">Connecting to the browser…</span>
     </div>
   </header>
@@ -823,7 +905,7 @@ const PAGE = `<!doctype html>
     <p id="placeholder">Waiting for the first frame…</p>
   </main>
   <footer>
-    <div class="bar">
+    <div class="bar takeover-only">
       <input id="kbd" type="text" autocomplete="off" autocapitalize="off" autocorrect="off"
         spellcheck="false" enterkeyhint="enter" placeholder="Type here">
       <div class="keys">
@@ -833,10 +915,18 @@ const PAGE = `<!doctype html>
         <button id="key-clear" class="key" type="button" aria-label="Clear the field" disabled>Clear</button>
       </div>
     </div>
+    <p class="ask approval-only">
+      <span class="ask-label">The agent is asking to</span>
+      <span id="action"></span>
+    </p>
     <p class="hint" id="hint">Typing goes straight to the browser</p>
-    <div class="row">
+    <div class="row takeover-only">
       <button id="handback" class="primary" type="button">&#9995; Hand back</button>
       <button id="abort" class="ghost" type="button"><span class="ghost-label">I can't do this</span></button>
+    </div>
+    <div class="row approval-only">
+      <button id="deny" class="primary" type="button">Deny</button>
+      <button id="approve" class="ghost" type="button"><span class="ghost-label">Hold to approve</span></button>
     </div>
   </footer>
   <div id="overlay" hidden>
@@ -859,6 +949,18 @@ const PAGE = `<!doctype html>
   var overlay = document.getElementById("overlay")
   var overlayTitle = document.getElementById("overlay-title")
   var overlayNote = document.getElementById("overlay-note")
+  var actionEl = document.getElementById("action")
+
+  /**
+   * Takeover or approval, decided by the relay that served this page. In
+   * approval mode the human is answering a question about one screenshot, not
+   * driving anything: the input row and the key bar are not on the page, and
+   * the two messages below are the only ones this side can produce.
+   */
+  var APPROVAL = document.body.dataset.mode === "approval"
+  var SENDABLE = APPROVAL
+    ? { approve: 1, deny: 1, ping: 1 }
+    : { tap: 1, char: 1, key: 1, clear: 1, scroll: 1, handback: 1, abort: 1, ping: 1 }
 
   var ws = null
   var retries = 0
@@ -878,10 +980,14 @@ const PAGE = `<!doctype html>
   // needed to place the ring, and they arrive in separate messages.
   var meta = null
   var focus = null
-  var HINT_DEFAULT = "Typing goes straight to the browser"
+  var HINT_DEFAULT = APPROVAL
+    ? "Approve needs a hold. Deny is one tap."
+    : "Typing goes straight to the browser"
   /** Long enough that a stray thumb cannot reach it, short enough to not annoy. */
   var HOLD_MS = 700
-  var HOLD_HINT = "Hold the button to stop the agent"
+  var HOLD_HINT = APPROVAL
+    ? "Hold the button to approve"
+    : "Hold the button to stop the agent"
   var QUEUE_HINT = "Reconnecting — your input is queued"
   var QUEUE_FULL_HINT = "Reconnecting — queue full, the oldest input was dropped"
   var hintTimer = null
@@ -924,6 +1030,9 @@ const PAGE = `<!doctype html>
   var dropped = 0
 
   function send(message) {
+    // The mode's vocabulary, enforced here as well as at the relay: a control
+    // that is not on this page cannot have its message leave it either.
+    if (!SENDABLE[message.type]) return
     if (ws && ws.readyState === 1) {
       ws.send(JSON.stringify(message))
       return
@@ -1334,9 +1443,28 @@ const PAGE = `<!doctype html>
     )
   }
 
-  function dragScroll(e) {
+  /**
+   * One finger on an approval pans the screenshot. There is no remote page to
+   * scroll — the frame is a still — and a magnified still you cannot move is
+   * a picture of the middle of the page.
+   */
+  function dragPan(e) {
+    var dx = e.clientX - press.lastX
+    var dy = e.clientY - press.lastY
+    press.lastX = e.clientX
+    press.lastY = e.clientY
+    setView(view.scale, view.tx + dx, view.ty + dy, false)
+  }
+
+  /** One finger: a scroll of the remote page, or a pan of the screenshot. */
+  function dragMove(e) {
     press.travel = Math.max(press.travel, Math.hypot(e.clientX - press.x, e.clientY - press.y))
-    if (press.travel < TAP_SLOP_PX || !box.h) return
+    if (press.travel < TAP_SLOP_PX) return
+    if (APPROVAL) {
+      dragPan(e)
+      return
+    }
+    if (!box.h) return
     var now = Date.now()
     if (now - press.sentAt < 60) return
     var stepped = e.clientY - press.lastY
@@ -1360,7 +1488,7 @@ const PAGE = `<!doctype html>
       beginPinch()
       return
     }
-    press = { x: e.clientX, y: e.clientY, lastY: e.clientY, travel: 0, sentAt: 0 }
+    press = { x: e.clientX, y: e.clientY, lastX: e.clientX, lastY: e.clientY, travel: 0, sentAt: 0 }
   })
   canvas.addEventListener("pointermove", function (e) {
     var point = pointers.get(e.pointerId)
@@ -1372,7 +1500,7 @@ const PAGE = `<!doctype html>
       updatePinch()
       return
     }
-    if (press) dragScroll(e)
+    if (press) dragMove(e)
   })
   /** Acknowledge the tap where the finger landed, inside the same frame. */
   function markTap(clientX, clientY) {
@@ -1437,6 +1565,9 @@ const PAGE = `<!doctype html>
       return
     }
     lastTap = { at: now, x: e.clientX, y: e.clientY }
+    // A single tap on an approval does nothing, and says so by doing nothing:
+    // an acknowledgement ripple would promise the remote page had seen it.
+    if (APPROVAL) return
     var point = toFrame(e.clientX, e.clientY)
     if (!point) return
     send({ type: "tap", fx: point.x, fy: point.y })
@@ -1565,75 +1696,96 @@ const PAGE = `<!doctype html>
     if (ws && !stillSending()) ws.close()
   }
 
-  // The expected ending, and the only one whose worst case is recoverable in
-  // spirit: the agent looks, fails and asks again. Confirming the happy path is
-  // the classic mistake, so this stays a single tap.
-  document.getElementById("handback").addEventListener("click", function () {
-    send({ type: "handback" })
-    finish(ENDINGS.resolved[0], ENDINGS.resolved[1])
-  })
-
-  /**
-   * Giving up ends the handoff for good and there is nothing to undo — the
-   * message leaves the socket and the agent settles on it immediately. So the
-   * gesture costs more than a tap instead of a confirm dialog costing a screen.
-   *
-   * Pointer events only: they cover mouse, touch and pen with one stream, so
-   * the hold cannot start twice from one finger.
-   */
-  var abortButton = document.getElementById("abort")
-  var holdTimer = null
-  var holdFired = false
-
   function flashHint(text) {
     hint.textContent = text
     if (hintTimer) clearTimeout(hintTimer)
     hintTimer = setTimeout(function () { hintTimer = null; setHint() }, 2200)
   }
 
-  function startHold() {
-    if (holdTimer || finished) return
-    abortButton.dataset.holding = ""
-    holdTimer = setTimeout(function () {
-      holdTimer = null
-      holdFired = true
-      delete abortButton.dataset.holding
-      if (navigator.vibrate) navigator.vibrate(20)
-      send({ type: "abort" })
-      finish("Thanks for looking", "The agent knows it can't be done here and will stop. You can close this tab.")
-    }, HOLD_MS)
-  }
+  /**
+   * Press-and-hold, for the one answer in each mode that cannot be taken back:
+   * giving up in a takeover, approving in an approval. The message leaves the
+   * socket and the agent settles on it immediately, so the gesture costs more
+   * than a tap instead of a confirm dialog costing a screen.
+   *
+   * Pointer events only: they cover mouse, touch and pen with one stream, so
+   * the hold cannot start twice from one finger.
+   */
+  function holdButton(button, run) {
+    var holdTimer = null
+    var holdFired = false
 
-  function cancelHold() {
-    if (holdTimer) { clearTimeout(holdTimer); holdTimer = null }
-    delete abortButton.dataset.holding
-  }
+    function startHold() {
+      if (holdTimer || finished) return
+      button.dataset.holding = ""
+      holdTimer = setTimeout(function () {
+        holdTimer = null
+        holdFired = true
+        delete button.dataset.holding
+        if (navigator.vibrate) navigator.vibrate(20)
+        run()
+      }, HOLD_MS)
+    }
 
-  abortButton.addEventListener("pointerdown", startHold)
-  abortButton.addEventListener("pointerup", cancelHold)
-  abortButton.addEventListener("pointercancel", cancelHold)
-  abortButton.addEventListener("pointerleave", cancelHold)
-  // A keyboard has no press-and-hold of its own, so held Space or Enter is the
-  // same contract. Without this the button is unreachable without a pointer.
-  abortButton.addEventListener("keydown", function (e) {
-    if (e.key !== " " && e.key !== "Enter") return
-    e.preventDefault()
-    if (!e.repeat) startHold()
-  })
-  abortButton.addEventListener("keyup", cancelHold)
-  // A release always fires a click. After a completed hold that click is the
-  // same gesture arriving twice; before 700ms it is a tap that did nothing, and
-  // a tap that does nothing has to say why or the human thinks it is broken.
-  abortButton.addEventListener("click", function () {
-    if (holdFired) { holdFired = false; return }
-    flashHint(HOLD_HINT)
-  })
+    function cancelHold() {
+      if (holdTimer) { clearTimeout(holdTimer); holdTimer = null }
+      delete button.dataset.holding
+    }
+
+    button.addEventListener("pointerdown", startHold)
+    button.addEventListener("pointerup", cancelHold)
+    button.addEventListener("pointercancel", cancelHold)
+    button.addEventListener("pointerleave", cancelHold)
+    // A keyboard has no press-and-hold of its own, so held Space or Enter is
+    // the same contract. Without this the button needs a pointer to reach.
+    button.addEventListener("keydown", function (e) {
+      if (e.key !== " " && e.key !== "Enter") return
+      e.preventDefault()
+      if (!e.repeat) startHold()
+    })
+    button.addEventListener("keyup", cancelHold)
+    // A release always fires a click. After a completed hold that click is the
+    // same gesture arriving twice; before 700ms it is a tap that did nothing,
+    // and a tap that does nothing has to say why or it reads as broken.
+    button.addEventListener("click", function () {
+      if (holdFired) { holdFired = false; return }
+      flashHint(HOLD_HINT)
+    })
+  }
 
   var ENDINGS = {
     resolved: ["Thanks — that unblocked it", "The agent is driving again. You can close this tab."],
     aborted: ["Handoff ended", "You couldn't solve it here. Nothing more to do — you can close this tab."],
+    approved: ["Approved", "The agent has your approval and is continuing. You can close this tab."],
+    denied: ["Denied", "The agent has been told not to do it. You can close this tab."],
     timeout: ["Too late", "The agent gave up waiting. Nothing you can do here now."],
     disconnected: ["Connection ended", "The remote browser closed. The agent has been told — this wasn't anything you did."]
+  }
+
+  if (APPROVAL) {
+    // Deny is a single tap because it is the answer that keeps the world as it
+    // is; approve is the hold, because it is the one that cannot be undone.
+    // That is the takeover's rule with the sides swapped, for the same reason.
+    document.getElementById("deny").addEventListener("click", function () {
+      send({ type: "deny" })
+      finish(ENDINGS.denied[0], ENDINGS.denied[1])
+    })
+    holdButton(document.getElementById("approve"), function () {
+      send({ type: "approve" })
+      finish(ENDINGS.approved[0], ENDINGS.approved[1])
+    })
+  } else {
+    // The expected ending, and the only one whose worst case is recoverable in
+    // spirit: the agent looks, fails and asks again. Confirming the happy path
+    // is the classic mistake, so this stays a single tap.
+    document.getElementById("handback").addEventListener("click", function () {
+      send({ type: "handback" })
+      finish(ENDINGS.resolved[0], ENDINGS.resolved[1])
+    })
+    holdButton(document.getElementById("abort"), function () {
+      send({ type: "abort" })
+      finish("Thanks for looking", "The agent knows it can't be done here and will stop. You can close this tab.")
+    })
   }
 
   function handle(raw) {
@@ -1641,7 +1793,12 @@ const PAGE = `<!doctype html>
     try { message = JSON.parse(raw) } catch (err) { return }
     if (!message) return
     if (message.type === "frame") showFrame(message.data, message.meta)
-    else if (message.type === "state") reason.textContent = message.reason
+    else if (message.type === "state") {
+      reason.textContent = message.reason
+      // textContent, never innerHTML: the action is the agent's own sentence,
+      // and it goes on the screen a decision is made from.
+      if (message.action) actionEl.textContent = message.action
+    }
     else if (message.type === "focus") {
       focus = readFocus(message)
       applyKind(focus.rect ? focus.kind : "text")
@@ -1699,6 +1856,13 @@ const PAGE = `<!doctype html>
     sock.onerror = function () { if (mine === generation) sock.close() }
   }
 
+  if (APPROVAL) {
+    // The page arrives phrased for a takeover, because that is what it is most
+    // of the time. These three lines are the rest of the difference.
+    document.getElementById("eyebrow-note").textContent = "an agent needs your approval"
+    placeholder.textContent = "Waiting for the screenshot…"
+    setHint()
+  }
   applyTransform(false)
   setInterval(function () { send({ type: "ping" }) }, 20000)
   window.addEventListener("resize", render)

--- a/src/relay/protocol.ts
+++ b/src/relay/protocol.ts
@@ -1,7 +1,14 @@
 /**
  * Wire protocol between the agent process, the relay (in a Solari sandbox),
- * and the human's phone. The relay is a dumb router: it forwards agent→human
- * and human→agent messages verbatim and never inspects payloads.
+ * and the human's phone. The relay forwards agent→human and human→agent
+ * messages verbatim; it reads their `type` and never their payload.
+ *
+ * It reads the type for one reason beyond replay: the handoff's mode is
+ * enforced there. The relay is started with the mode as an argument and routes
+ * only the human messages that mode allows — the takeover set below in
+ * takeover mode, `approve` and `deny` in approval mode. Hiding a control on
+ * the phone is not a restriction; the human's socket is reachable from any
+ * HTTP client.
  *
  * Both sides connect to `wss://<preview>/ws?role=agent|human`. Coordinates in
  * human messages are frame pixels (the JPEG the phone displays); the agent
@@ -10,7 +17,13 @@
  * scale by deviceWidth / jpegWidth, never add scroll offsets).
  */
 
-/** Screencast frame metadata, passed through from CDP unmodified. */
+import type { HandoffOutcome } from "../types"
+
+/**
+ * Screencast frame metadata, passed through from CDP unmodified. In approval
+ * mode there is one frame and it is a screenshot, but it carries the same
+ * metadata so the phone's letterbox maths does not care which it is.
+ */
 export interface FrameMeta {
   /** CSS viewport width of the remote page (unscaled, from CDP metadata). */
   deviceWidth: number
@@ -46,7 +59,11 @@ export type FocusKind = "otp" | "password" | "text"
 
 export type AgentToHuman =
   | { type: "frame"; data: string; meta: FrameMeta }
-  | { type: "state"; reason: string }
+  /**
+   * Why the human is here. `action` is sent in approval mode only and carries
+   * the step being decided; the phone shows it as the largest text on screen.
+   */
+  | { type: "state"; reason: string; action?: string }
   /**
    * Where the human's typing currently lands. `rect: null` means nothing is
    * focused; `label` is a human-readable field name taken from the remote
@@ -62,10 +79,7 @@ export type AgentToHuman =
       label: string | null
       kind?: FocusKind
     }
-  | {
-      type: "ended"
-      outcome: "resolved" | "aborted" | "timeout" | "disconnected"
-    }
+  | { type: "ended"; outcome: HandoffOutcome }
 
 export type HumanToAgent =
   | { type: "tap"; fx: number; fy: number }
@@ -81,6 +95,13 @@ export type HumanToAgent =
   | { type: "scroll"; fdy: number }
   | { type: "handback" }
   | { type: "abort" }
+  /**
+   * The two approval answers, and the only human messages an approval relay
+   * routes. `deny` is one tap on the phone and `approve` takes a hold: in this
+   * mode the irreversible side is yes.
+   */
+  | { type: "approve" }
+  | { type: "deny" }
 
 /**
  * Either side may ping; the receiver answers pong. Required: the preview

--- a/src/relay/relay.test.ts
+++ b/src/relay/relay.test.ts
@@ -147,6 +147,49 @@ async function connect(port: number, role: "agent" | "human"): Promise<Client> {
   }
 }
 
+/**
+ * Resolve when the relay logs a given event with the given fields. The relay
+ * writes one JSON line per event to stdout; this reads them. Arm it before the
+ * action that causes the event, so the line cannot land before we are looking.
+ *
+ * `agent.closed` only tells us the client's socket is down — the server may not
+ * have run its close handler yet. When a test's next step depends on that
+ * handler having run (a scrubbed buffer, a freed role), wait for its log line
+ * instead of the client close, or the two race.
+ */
+function waitForLog(
+  relay: Relay,
+  event: string,
+  fields: Record<string, string>,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    let buffered = ""
+    const onData = (chunk: Buffer): void => {
+      buffered += chunk.toString("utf8")
+      for (const line of buffered.split("\n")) {
+        if (!line.includes(`"event":"${event}"`)) continue
+        const all = Object.entries(fields).every(([key, value]) =>
+          line.includes(`"${key}":"${value}"`),
+        )
+        if (all) {
+          cleanup()
+          resolve()
+          return
+        }
+      }
+    }
+    const timer = setTimeout(() => {
+      cleanup()
+      reject(new Error(`no ${event} log within ${MESSAGE_TIMEOUT_MS}ms`))
+    }, MESSAGE_TIMEOUT_MS)
+    const cleanup = (): void => {
+      clearTimeout(timer)
+      relay.process.stdout.removeListener("data", onData)
+    }
+    relay.process.stdout.on("data", onData)
+  })
+}
+
 let relay: Relay
 
 beforeEach(async () => {
@@ -588,8 +631,13 @@ test("the replay buffer is dropped when the agent disconnects, and restored when
     reason: "Aurora Bank is asking for a code",
   })
 
+  // Arm the wait before the close so the log line cannot slip past us, then
+  // wait for the server to have run its close handler — not just the client
+  // socket to be down — before a late human can prove the buffer is gone.
+  const scrubbed = waitForLog(relay, "peer closed", { role: "agent" })
   agent.socket.close()
   await agent.closed
+  await scrubbed
   const late = await connect(relay.port, "human")
   await expect(late.next()).rejects.toThrow(/no message/)
 

--- a/src/relay/relay.test.ts
+++ b/src/relay/relay.test.ts
@@ -518,3 +518,89 @@ test("a deny reaches an agent that reconnects after the human sent it", async ()
   const second = await connect(approval.port, "agent")
   expect(await second.next()).toEqual({ type: "deny" })
 })
+
+test("the first terminal answer wins, and a second holder cannot overturn it", async () => {
+  // The handoff link is a bearer URL and may be shared. Two people can hold it
+  // at once, and the relay hands the agent whichever answer arrived while it
+  // was away — so the second one must not be able to overwrite a denial with
+  // an approval.
+  const approval = await startRelayProcess("", "approval")
+  const first = await connect(approval.port, "agent")
+  const human = await connect(approval.port, "human")
+
+  first.socket.close()
+  await first.closed
+  human.send({ type: "deny" })
+  human.send({ type: "approve" })
+
+  const second = await connect(approval.port, "agent")
+  expect(await second.next()).toEqual({ type: "deny" })
+  // And nothing else: the approval was dropped, not queued behind it.
+  await expect(second.next()).rejects.toThrow(/no message/)
+})
+
+test("a takeover answer is terminal too: an abort cannot follow a handback", async () => {
+  const agent = await connect(relay.port, "agent")
+  const human = await connect(relay.port, "human")
+
+  human.send({ type: "handback" })
+  human.send({ type: "abort" })
+  human.send({ type: "tap", fx: 1, fy: 2 })
+
+  expect(await agent.next()).toEqual({ type: "handback" })
+  await expect(agent.next()).rejects.toThrow(/no message/)
+})
+
+test("an agent frame after the human answered is not replayed to a late human", async () => {
+  const approval = await startRelayProcess("", "approval")
+  const agent = await connect(approval.port, "agent")
+  const human = await connect(approval.port, "human")
+
+  agent.send({ type: "state", reason: "may I pay this invoice?" })
+  agent.send({ type: "frame", data: "c2NyZWVuc2hvdA==", meta: META })
+  expect(await human.next()).toEqual({
+    type: "state",
+    reason: "may I pay this invoice?",
+  })
+  human.send({ type: "deny" })
+  expect(await agent.next()).toEqual({ type: "deny" })
+
+  // A reconnecting agent re-sends what it has. The handoff is over, so none of
+  // it may go back into the replay buffer the next visitor is served from.
+  agent.send({ type: "state", reason: "may I pay this invoice?" })
+  agent.send({ type: "frame", data: "c2NyZWVuc2hvdA==", meta: META })
+  await Bun.sleep(150)
+
+  const late = await connect(approval.port, "human")
+  await expect(late.next()).rejects.toThrow(/no message/)
+})
+
+test("the replay buffer is dropped when the agent disconnects, and restored when it returns", async () => {
+  // If the agent dies without delivering its `ended` — a timeout during an
+  // outage, a killed process — the relay would otherwise keep serving the
+  // page's last frame to anyone holding the link until the sandbox idles out.
+  const agent = await connect(relay.port, "agent")
+  agent.send({ type: "state", reason: "Aurora Bank is asking for a code" })
+  agent.send({ type: "frame", data: "Zmlyc3QtZnJhbWU=", meta: META })
+  const human = await connect(relay.port, "human")
+  expect(await human.next()).toEqual({
+    type: "state",
+    reason: "Aurora Bank is asking for a code",
+  })
+
+  agent.socket.close()
+  await agent.closed
+  const late = await connect(relay.port, "human")
+  await expect(late.next()).rejects.toThrow(/no message/)
+
+  // A handoff that is still running recovers on its own: the agent reconnects
+  // and re-sends its state, and the next visitor sees it again.
+  const back = await connect(relay.port, "agent")
+  back.send({ type: "state", reason: "Aurora Bank is asking for a code" })
+  await Bun.sleep(150)
+  const later = await connect(relay.port, "human")
+  expect(await later.next()).toEqual({
+    type: "state",
+    reason: "Aurora Bank is asking for a code",
+  })
+})

--- a/src/relay/relay.test.ts
+++ b/src/relay/relay.test.ts
@@ -14,7 +14,7 @@ import { connect as netConnect, type Socket } from "node:net"
 import type { Readable } from "node:stream"
 import { fileURLToPath } from "node:url"
 import WebSocket from "ws"
-
+import type { HandoffMode } from "../types"
 import { GUEST_SERVER_JS } from "./guest-source"
 import {
   HEARTBEAT_INTERVAL_MS,
@@ -59,13 +59,21 @@ function parse(raw: string): RelayMessage {
 /** Processes spawned by an individual test; torn down in afterEach. */
 const extraProcesses: ChildProcessByStdio<null, Readable, Readable>[] = []
 
-/** Start the real server on an OS-assigned port and read the port back out of its log. */
-function startRelayProcess(agentKey?: string): Promise<Relay> {
-  const args = agentKey ? [SERVER_PATH, "0", agentKey] : [SERVER_PATH, "0"]
+/**
+ * Start the real server on an OS-assigned port and read the port back out of
+ * its log. `mode` is argv and not a message: what the human may send is fixed
+ * when the relay boots, so it cannot be talked out of it afterwards.
+ */
+function startRelayProcess(
+  agentKey?: string,
+  mode?: HandoffMode,
+): Promise<Relay> {
+  const args = [SERVER_PATH, "0", agentKey ?? ""]
+  if (mode) args.push(mode)
   const child = spawn(process.execPath, args, {
     stdio: ["ignore", "pipe", "pipe"],
   })
-  if (agentKey) extraProcesses.push(child)
+  if (agentKey || mode) extraProcesses.push(child)
   return new Promise<Relay>((resolve, reject) => {
     const timer = setTimeout(() => {
       child.kill("SIGKILL")
@@ -453,4 +461,60 @@ test("a replaced agent can no longer inject messages", async () => {
   expect(reasons).toContain("legit")
   expect(reasons).not.toContain("injected")
   stale.socket.destroy()
+})
+
+test("approval mode drops every takeover message the human sends", async () => {
+  const approval = await startRelayProcess("", "approval")
+  const agent = await connect(approval.port, "agent")
+  const human = await connect(approval.port, "human")
+
+  // Hiding the controls is not enough: the human's socket is reachable from
+  // any HTTP client, so the refusal has to be the relay's, not the page's.
+  human.send({ type: "tap", fx: 10, fy: 10 })
+  human.send({ type: "char", ch: "a" })
+  human.send({ type: "key", key: "Enter" })
+  human.send({ type: "clear" })
+  human.send({ type: "scroll", fdy: 40 })
+  human.send({ type: "handback" })
+  human.send({ type: "abort" })
+  // Only this one is in the approval vocabulary, and it arrives after all of
+  // them, so receiving it proves the others were dropped and not merely slow.
+  human.send({ type: "approve" })
+
+  expect(await agent.next()).toEqual({ type: "approve" })
+})
+
+test("takeover mode drops the approval answers", async () => {
+  const agent = await connect(relay.port, "agent")
+  const human = await connect(relay.port, "human")
+
+  human.send({ type: "approve" })
+  human.send({ type: "deny" })
+  human.send({ type: "handback" })
+
+  expect(await agent.next()).toEqual({ type: "handback" })
+})
+
+test("an approval relay serves the page in approval mode", async () => {
+  const approval = await startRelayProcess("", "approval")
+
+  const page = await fetch(`http://127.0.0.1:${approval.port}/`)
+  const html = await page.text()
+  expect(html).toContain('data-mode="approval"')
+  // The same file serves both modes, so an approval page that still offered
+  // the keyboard would render controls the relay refuses to route.
+  expect(html).toContain("Hold to approve")
+})
+
+test("a deny reaches an agent that reconnects after the human sent it", async () => {
+  const approval = await startRelayProcess("", "approval")
+  const first = await connect(approval.port, "agent")
+  const human = await connect(approval.port, "human")
+
+  first.socket.close()
+  await first.closed
+  human.send({ type: "deny" })
+
+  const second = await connect(approval.port, "agent")
+  expect(await second.next()).toEqual({ type: "deny" })
 })

--- a/src/tool.test.ts
+++ b/src/tool.test.ts
@@ -1,0 +1,49 @@
+/**
+ * The LLM-facing surface. Everything here is what a model reads or is bound
+ * by — the schema it fills in and the one refusal the tool makes on its own.
+ *
+ *   bun test src/tool.test.ts
+ */
+import { expect, test } from "bun:test"
+import type { Page } from "playwright-core"
+
+import { createNeedHumanTool, needHumanToolSpec } from "./tool"
+
+/**
+ * A page the tool must never reach: every test here stops before `raiseHand`.
+ */
+// SAFETY: the refusal under test happens before the page is touched, so no
+// member of Page is ever read from this object.
+const UNUSED_PAGE = {} as Page
+
+test("the spec offers both modes and names the choice between them", () => {
+  const { properties, required } = needHumanToolSpec.inputSchema
+  expect(properties.mode.enum).toEqual(["takeover", "approval"])
+  // `action` stays optional in the schema: the tool, not JSON Schema, is what
+  // rejects an approval without one, and its message tells the model how.
+  expect(required).toEqual(["reason"])
+
+  // The description has to make the difference decidable by a model that has
+  // only this text — "cannot" versus "not allowed to".
+  expect(needHumanToolSpec.description).toContain("cannot do it yourself")
+  expect(needHumanToolSpec.description).toContain("not allowed to decide alone")
+})
+
+test("an approval without an action is refused, and says what is missing", async () => {
+  const needHuman = createNeedHumanTool(UNUSED_PAGE)
+
+  const asking = needHuman({
+    mode: "approval",
+    reason: "I may not move money without a human",
+  })
+
+  // Silently downgrading to a takeover would put a blank question on a phone
+  // and hand the browser over instead of asking about a step.
+  await expect(asking).rejects.toThrow(/needHuman: mode "approval" needs an/)
+})
+
+test("a takeover call needs no action and is the default", () => {
+  const spec = needHumanToolSpec.inputSchema.properties
+  expect(spec.mode.description).toContain("default")
+  expect(spec.action.description).toContain('Required with mode "approval"')
+})

--- a/src/tool.test.ts
+++ b/src/tool.test.ts
@@ -47,3 +47,17 @@ test("a takeover call needs no action and is the default", () => {
   expect(spec.mode.description).toContain("default")
   expect(spec.action.description).toContain('Required with mode "approval"')
 })
+
+test("an approval whose action is only whitespace is refused too", async () => {
+  const needHuman = createNeedHumanTool(UNUSED_PAGE)
+
+  const asking = needHuman({
+    mode: "approval",
+    reason: "I may not move money without a human",
+    action: "   ",
+  })
+
+  // A blank line on a phone is not a decision, and " " passes a truthiness
+  // check — which is exactly how this one gets shipped.
+  await expect(asking).rejects.toThrow(/needHuman: mode "approval" needs an/)
+})

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -22,7 +22,8 @@ export const needHumanToolSpec = {
     'have changed. Use mode "approval" when you could do it but are not ' +
     "allowed to decide alone — paying, sending, deleting: the human sees one " +
     "screenshot and the `action` you name, and answers yes or no while the " +
-    "browser stays yours.",
+    "browser stays yours. That screenshot is the page exactly as it is when " +
+    "you call this, so navigate and fill the form in first, then ask.",
   inputSchema: {
     type: "object",
     properties: {
@@ -73,7 +74,8 @@ export type NeedHumanDefaults = Omit<HandoffOptions, "reason">
 
 /**
  * What each ending means to a model that has never seen the outcome enum.
- * Approval mode can only produce the middle two; takeover only the first two.
+ * Takeover reaches the first two, approval the middle two, and both can end in
+ * `timeout` or `disconnected` — which is why there are six.
  */
 const SUMMARIES = {
   resolved:
@@ -102,7 +104,7 @@ function optionsFor(
   input: NeedHumanInput,
 ): RaiseHandOptions {
   if (input.mode !== "approval") return { ...defaults, reason: input.reason }
-  if (!input.action) {
+  if (!input.action?.trim()) {
     throw new Error(
       'needHuman: mode "approval" needs an `action` — the concrete step the human says yes or no to. Call it again with one, or use the default takeover mode if you are stuck rather than blocked.',
     )

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -1,6 +1,11 @@
 import type { Page } from "playwright-core"
 import { raiseHand } from "./core/raise-hand"
-import type { HandoffOutcome, RaiseHandOptions } from "./types"
+import type {
+  HandoffMode,
+  HandoffOptions,
+  HandoffOutcome,
+  RaiseHandOptions,
+} from "./types"
 
 /**
  * Tool metadata for LLM agents, framework-agnostic: plain JSON Schema, no
@@ -10,19 +15,38 @@ import type { HandoffOutcome, RaiseHandOptions } from "./types"
 export const needHumanToolSpec = {
   name: "needHuman",
   description:
-    "Hand the live browser session to a human and wait. Call this when you " +
-    "are stuck: a 2FA prompt, a captcha you cannot solve, or a page you do " +
-    "not understand. A human sees the browser on their phone, fixes the " +
-    "problem, and hands back. Afterwards, re-read the page — it will have " +
-    "changed.",
+    'Put the browser in front of a human and wait. Use mode "takeover" ' +
+    "(the default) when you cannot do it yourself — a 2FA prompt, a captcha, " +
+    "a page you do not understand: the human drives the session on their " +
+    "phone, fixes it and hands back, so re-read the page afterwards, it will " +
+    'have changed. Use mode "approval" when you could do it but are not ' +
+    "allowed to decide alone — paying, sending, deleting: the human sees one " +
+    "screenshot and the `action` you name, and answers yes or no while the " +
+    "browser stays yours.",
   inputSchema: {
     type: "object",
     properties: {
       reason: {
         type: "string",
         description:
-          "What you are stuck on, phrased for the human who will help, " +
-          'e.g. "GitHub is asking for a 2FA code".',
+          "Why you are asking, phrased for the human who will answer, " +
+          'e.g. "GitHub is asking for a 2FA code" or "I may not move money ' +
+          'without a human".',
+      },
+      mode: {
+        type: "string",
+        enum: ["takeover", "approval"],
+        description:
+          '"takeover" (default) when you are stuck and need the human to do ' +
+          'it; "approval" when you know how to do it but need a yes first.',
+      },
+      action: {
+        type: "string",
+        description:
+          'Required with mode "approval": the exact step being decided, ' +
+          'e.g. "Submit $12,430 vendor payment to Acme GmbH". This is the ' +
+          "sentence the human says yes or no to, so write it as the step and " +
+          "not as a question.",
       },
     },
     required: ["reason"],
@@ -32,6 +56,10 @@ export const needHumanToolSpec = {
 
 export interface NeedHumanInput {
   reason: string
+  /** Defaults to "takeover". */
+  mode?: HandoffMode
+  /** The step being decided. Required when `mode` is "approval". */
+  action?: string
 }
 
 export interface NeedHumanOutput {
@@ -41,7 +69,51 @@ export interface NeedHumanOutput {
   durationMs: number
 }
 
-export type NeedHumanDefaults = Omit<RaiseHandOptions, "reason">
+export type NeedHumanDefaults = Omit<HandoffOptions, "reason">
+
+/**
+ * What each ending means to a model that has never seen the outcome enum.
+ * Approval mode can only produce the middle two; takeover only the first two.
+ */
+const SUMMARIES = {
+  resolved:
+    "A human fixed the problem and handed the browser back. Re-read the page and continue.",
+  aborted:
+    "The human looked at the problem and aborted the handoff. Do not retry the same step; report why you were stuck.",
+  approved:
+    "The human approved the action. Carry it out now, exactly as you described it.",
+  denied:
+    "The human refused the action. Do not carry it out and do not ask again for the same step; report that it was denied.",
+  timeout:
+    "No human responded in time. Report that you are blocked on human help.",
+  disconnected:
+    "The browser session died while waiting for the human. The page object is no longer usable; the session must be relaunched.",
+} satisfies Record<HandoffOutcome, string>
+
+/**
+ * Turn what the model asked for into `raiseHand` options.
+ *
+ * A model that asks for an approval without naming the action gets an error
+ * rather than a takeover: the whole point of the mode is that a human decides
+ * on a concrete step, and a missing one would put a blank question on a phone.
+ */
+function optionsFor(
+  defaults: NeedHumanDefaults,
+  input: NeedHumanInput,
+): RaiseHandOptions {
+  if (input.mode !== "approval") return { ...defaults, reason: input.reason }
+  if (!input.action) {
+    throw new Error(
+      'needHuman: mode "approval" needs an `action` — the concrete step the human says yes or no to. Call it again with one, or use the default takeover mode if you are stuck rather than blocked.',
+    )
+  }
+  return {
+    ...defaults,
+    mode: "approval",
+    reason: input.reason,
+    action: input.action,
+  }
+}
 
 /**
  * Bind `raiseHand` to a page so an LLM agent can call it as a tool.
@@ -57,17 +129,11 @@ export function createNeedHumanTool(
   defaults: NeedHumanDefaults = {},
 ): (input: NeedHumanInput) => Promise<NeedHumanOutput> {
   return async (input: NeedHumanInput): Promise<NeedHumanOutput> => {
-    const result = await raiseHand(page, { ...defaults, reason: input.reason })
-    const summary = {
-      resolved:
-        "A human fixed the problem and handed the browser back. Re-read the page and continue.",
-      aborted:
-        "The human looked at the problem and aborted the handoff. Do not retry the same step; report why you were stuck.",
-      timeout:
-        "No human responded in time. Report that you are blocked on human help.",
-      disconnected:
-        "The browser session died while waiting for the human. The page object is no longer usable; the session must be relaunched.",
-    }[result.outcome]
-    return { outcome: result.outcome, summary, durationMs: result.durationMs }
+    const result = await raiseHand(page, optionsFor(defaults, input))
+    return {
+      outcome: result.outcome,
+      summary: SUMMARIES[result.outcome],
+      durationMs: result.durationMs,
+    }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,8 +2,17 @@ import type { BrowserContext, Page } from "playwright-core"
 import type { HandoffEvent } from "./events"
 import type { Logger } from "./logger"
 
-/** Why the agent is raising its hand — shown to the human on the handoff page. */
-export interface RaiseHandOptions {
+/**
+ * What the human is being asked for.
+ *
+ * `takeover` is the original handoff: the human drives the live browser and
+ * hands it back. `approval` asks one question about one screenshot — the agent
+ * keeps the browser, and the human only answers yes or no.
+ */
+export type HandoffMode = "takeover" | "approval"
+
+/** The options both modes share. */
+export interface HandoffOptions {
   /** Human-readable reason, e.g. "GitHub is asking for a 2FA code". */
   reason: string
   /**
@@ -48,9 +57,51 @@ export interface RaiseHandOptions {
   baseUrl?: string
 }
 
+/** The agent is stuck and wants the browser driven. The default. */
+export interface TakeoverOptions extends HandoffOptions {
+  mode?: "takeover"
+}
+
+/**
+ * The agent is not stuck; it is about to do something it may not do alone.
+ * `action` is required here because it is the thing being decided — a reason
+ * without it asks the human to approve a sentence, not a step.
+ */
+export interface ApprovalOptions extends HandoffOptions {
+  mode: "approval"
+  /**
+   * The concrete step awaiting a yes or a no, e.g. "Submit $12,430 vendor
+   * payment to Acme GmbH". Shown to the human as the largest text on the page.
+   */
+  action: string
+}
+
+/**
+ * Options for `raiseHand`. A discriminated union on `mode`: omitting it is a
+ * takeover and compiles exactly as it did before approval mode existed, while
+ * `mode: "approval"` will not compile without an `action`.
+ */
+export type RaiseHandOptions = TakeoverOptions | ApprovalOptions
+
 export type StorageState = Awaited<ReturnType<BrowserContext["storageState"]>>
 
-export type HandoffOutcome = "resolved" | "aborted" | "timeout" | "disconnected"
+/**
+ * How a handoff ended. Which values are reachable depends on the mode:
+ *
+ * - takeover: `resolved` (the human handed back), `aborted` (the human gave
+ *   up), `timeout`, `disconnected`.
+ * - approval: `approved`, `denied`, `timeout`, `disconnected`.
+ *
+ * The four modes-in-common cases keep their meaning, so a `switch` written
+ * before approval mode still compiles and still branches the same way.
+ */
+export type HandoffOutcome =
+  | "resolved"
+  | "aborted"
+  | "approved"
+  | "denied"
+  | "timeout"
+  | "disconnected"
 
 export interface HandoffResult {
   outcome: HandoffOutcome
@@ -67,15 +118,22 @@ export interface HandoffResult {
 }
 
 /**
- * Pause the agent and hand the live browser session to a human.
+ * Pause the agent and put the browser session in front of a human.
  *
- * Resolves when the human clicks "hand back" (outcome: "resolved"), the human
- * aborts (outcome: "aborted"), `timeoutMs` elapses (outcome: "timeout"), or
+ * In takeover mode it resolves when the human clicks "hand back" (outcome:
+ * "resolved"), the human gives up (outcome: "aborted"), `timeoutMs` elapses
+ * (outcome: "timeout"), or
  * the browser session dies mid-handoff (outcome: "disconnected" — on the plan
  * we measured, Solari browser sessions had a hard ~10 minute lifetime and the
  * sessions API kept reporting "active" after death, so liveness comes from the
- * connection, not the control plane). All relay infrastructure is destroyed
- * before this promise settles, on every path including errors.
+ * connection, not the control plane).
+ *
+ * In approval mode the human sees one screenshot and the `action`, and the
+ * outcome is "approved" or "denied" instead. Nothing is injected into the
+ * page, so the session is exactly as the agent left it.
+ *
+ * All relay infrastructure is destroyed before this promise settles, on every
+ * path including errors.
  */
 export type RaiseHand = (
   page: Page,


### PR DESCRIPTION
Adds approval mode to `raiseHand`. A capability gap ("I can't do this": 2FA, a captcha) and an authority boundary ("I may not do this": submit the payment) were the same call with a different `reason`. They are now two modes, and an approval needs no takeover: the human sees one screenshot and the action in words, and answers yes or no. Deny is one tap; approve takes the 700 ms hold, because in this mode the answer that cannot be undone is yes (ADR 0006).

```ts
const result = await raiseHand(page, {
  mode: "approval",
  reason: "I may not move money without a human",
  action: "Submit EUR 12,430 vendor payment to Acme GmbH",
})
// result.outcome: "approved" | "denied" | "timeout" | "disconnected"
```

**Enforced at the relay, not on the phone.** The relay is started as a takeover or an approval relay and routes only that mode's human messages. In approval mode no CDP session is opened at all: no screencast, no input, no focus probe, no `storageState`. The live e2e installs `pointerdown`/`keydown`/`input` counters in the real page, sends a tap and a character during the approval, and asserts all three stay 0.

**Fixes found on the way, all pre-existing in takeover mode too:**

- The phone's Clear key did nothing: `clear` was never listed in the agent's message switch. A test now sends one of every `HumanToAgent` member through the real relay and socket.
- First answer wins. A holder of the bearer link could overwrite a queued `deny`/`abort` with `approve`/`handback` while the agent was reconnecting. The relay now keeps a sticky terminal state.
- A lost `ended` could leave the last logged-in frame replayable to a late link holder. The relay scrubs its replay buffers when the agent socket closes; a live handoff restores them on reconnect.
- An answer given while the phone's socket was already closing was silently dropped. The page now reconnects to flush it.

**Breaking for TypeScript consumers** (compile-time only, disclosed in the CHANGELOG): `HandoffOutcome` has two new members, `HandoffEvent.mode` is new and required, and `RaiseHandOptions` is now a union (`extends` needs `HandoffOptions` or `TakeoverOptions`).

**Verification:** lint, typecheck, 180 tests (unit, relay, real-Chromium UI), build, dist smoke, live e2e against Solari (takeover resolved, approve 5.2 s wall, deny 5.1 s wall, timeout case, relays destroyed). Complexity ratchet unchanged. Reviewed by an Opus code-reviewer pass and a GPT-5.6 Sol adversarial pass; every finding from both is fixed here except one, below.

**Known gap, documented:** in approval mode the relayed `ended` can lose the race against the sandbox kill. The phone that answered shows its own ending; a second viewer of the same link may see nothing. Needs a protocol ack, tracked for 0.5.

Not in this PR: version bump, tag, publish (0.3.0 is still to be published first), the mixed takeover/approval bench, channel adapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
